### PR TITLE
Add version to `crust` binary so tool is recompiled automatically whenever changes are pulled from repository

### DIFF
--- a/bin/crust
+++ b/bin/crust
@@ -1,19 +1,27 @@
 #!/bin/bash
 
+# Increment VERSION if logic inside `./build` has changed. It guarantees that changes will be applied
+# automatically for all the developers once they are pulled from master.
+VERSION=1
+
 set -e
 
 # go to root dir of repository
 pushd "$(dirname "${BASH_SOURCE[0]}")/.." > /dev/null
-if [ ! -f ./bin/.cache/crust ]; then
-  pushd build > /dev/null
-  go build -trimpath -o ../bin/.cache/crust-tmp ./cmd
-  popd > /dev/null
-
-  ./bin/.cache/crust-tmp build/crust
-  rm -f ./bin/.cache/crust-tmp
-fi
 
 REPO=$(pwd)
+CRUST_BIN="$REPO/bin/.cache/crust-$VERSION"
+
+if [ ! -f "$CRUST_BIN" ]; then
+  rm -f ./bin/.cache/crust*
+
+  pushd build > /dev/null
+  go build -trimpath -o "$CRUST_BIN" ./cmd
+  popd > /dev/null
+
+  "$CRUST_BIN" build/crust
+fi
+
 popd > /dev/null
 
 case "$1" in
@@ -37,6 +45,6 @@ case "$1" in
      ;;
 
    *)
-     exec "$REPO/bin/.cache/crust" "$@"
+     exec "$CRUST_BIN" "$@"
      ;;
 esac

--- a/bin/crust
+++ b/bin/crust
@@ -1,14 +1,11 @@
 #!/bin/bash
 
-# Increment VERSION if logic inside `./build` has changed. It guarantees that changes will be applied
-# automatically for all the developers once they are pulled from master.
-VERSION=1
-
 set -e
 
 # go to root dir of repository
 pushd "$(dirname "${BASH_SOURCE[0]}")/.." > /dev/null
 
+VERSION=$(git rev-parse --short HEAD)
 REPO=$(pwd)
 CRUST_BIN="$REPO/bin/.cache/crust-$VERSION"
 

--- a/build/build.go
+++ b/build/build.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 
 	"github.com/CoreumFoundation/coreum-tools/pkg/build"
+	"github.com/CoreumFoundation/coreum-tools/pkg/must"
 	"github.com/pkg/errors"
 )
 
@@ -25,7 +26,7 @@ func buildCored(ctx context.Context, deps build.DepsFunc) error {
 
 func buildCrust(ctx context.Context, deps build.DepsFunc) error {
 	deps(ensureGo)
-	return goBuildPkg(ctx, "build/cmd", runtime.GOOS, "bin/.cache/crust", false)
+	return goBuildPkg(ctx, "build/cmd", runtime.GOOS, must.String(filepath.EvalSymlinks(must.String(os.Executable()))), false)
 }
 
 func buildZNet(ctx context.Context, deps build.DepsFunc) error {


### PR DESCRIPTION
Now, when logic of `crust` is changed all the developers must execute `crust build/crust` manually. It leads to situations when all team members must be notified to do it. After merging this PR, `crust` will be recompiled automatically for everyone after pulling new commits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coreumfoundation/crust/18)
<!-- Reviewable:end -->
