### PR TITLE
Incorporate gas limit and gas price into client and integration tests

### DIFF
--- a/infra/apps/cored/genesis.go
+++ b/infra/apps/cored/genesis.go
@@ -117,7 +117,7 @@ func (g *Genesis) AddValidator(validatorPublicKey ed25519.PublicKey, stakerPriva
 	msg, err := stakingtypes.NewMsgCreateValidator(sdk.ValAddress(stakerAddress), valPubKey, amount, stakingtypes.Description{Moniker: stakerAddress.String()}, commission, sdk.OneInt())
 	must.OK(err)
 
-	g.genutilState.GenTxs = append(g.genutilState.GenTxs, must.Bytes(g.clientCtx.TxConfig.TxJSONEncoder()(signTx(g.clientCtx, Wallet{Key: stakerPrivateKey}, msg, ""))))
+	g.genutilState.GenTxs = append(g.genutilState.GenTxs, must.Bytes(g.clientCtx.TxConfig.TxJSONEncoder()(signTx(g.clientCtx, SigningInput{Signer: Wallet{Key: stakerPrivateKey}}, msg, ""))))
 }
 
 // Save saves genesis configuration

--- a/pkg/znet/commands.go
+++ b/pkg/znet/commands.go
@@ -281,7 +281,14 @@ func sendTokens(ctx context.Context, client cored.Client, from, to cored.Wallet)
 	log := logger.Get(ctx)
 
 	amount := cored.Balance{Amount: big.NewInt(1), Denom: "core"}
-	txBytes, err := client.PrepareTxBankSend(ctx, cored.TxBankSendData{
+	txBytes, err := client.PrepareTxBankSend(ctx, cored.TxBankSendInput{
+		Signing: cored.SigningInput{
+			Signer: from,
+			// FIXME (wojtek): Take this value from Network.TxBankSendGas() once Milad integrates it into crust
+			GasLimit: 120000,
+			// FIXME (wojtek): Take this value from Network.InitialGasPrice() once Milad integrates it into crust
+			GasPrice: big.NewInt(1500),
+		},
 		Sender:   from,
 		Receiver: to,
 		Balance:  amount})

--- a/pkg/zstress/stress.go
+++ b/pkg/zstress/stress.go
@@ -151,7 +151,14 @@ func prepareTransactions(ctx context.Context, config StressConfig, client cored.
 						if !ok {
 							return nil
 						}
-						tx.TxBytes = must.Bytes(client.PrepareTxBankSend(ctx, cored.TxBankSendData{
+						tx.TxBytes = must.Bytes(client.PrepareTxBankSend(ctx, cored.TxBankSendInput{
+							Signing: cored.SigningInput{
+								Signer: tx.From,
+								// FIXME (wojtek): Take this value from Network.TxBankSendGas() once Milad integrates it into crust
+								GasLimit: 120000,
+								// FIXME (wojtek): Take this value from Network.InitialGasPrice() once Milad integrates it into crust
+								GasPrice: big.NewInt(1500),
+							},
 							Sender:   tx.From,
 							Receiver: tx.To,
 							Balance:  cored.Balance{Amount: big.NewInt(1), Denom: "core"},

--- a/tests/auth/sequence.go
+++ b/tests/auth/sequence.go
@@ -17,7 +17,7 @@ func TestUnexpectedSequenceNumber(chain cored.Cored) (testing.PrepareFunc, testi
 	var sender cored.Wallet
 
 	return func(ctx context.Context) error {
-			sender = chain.AddWallet("10core")
+			sender = chain.AddWallet("180000010core")
 			return nil
 		},
 		func(ctx context.Context, t *testing.T) {
@@ -32,7 +32,14 @@ func TestUnexpectedSequenceNumber(chain cored.Cored) (testing.PrepareFunc, testi
 			sender.AccountSequence = accSeq + 1 // Intentionally set incorrect sequence number
 
 			// Broadcast a transaction using incorrect sequence number
-			txBytes, err := client.PrepareTxBankSend(ctx, cored.TxBankSendData{
+			txBytes, err := client.PrepareTxBankSend(ctx, cored.TxBankSendInput{
+				Signing: cored.SigningInput{
+					Signer: sender,
+					// FIXME (wojtek): Take this value from Network.TxBankSendGas() once Milad integrates it into crust
+					GasLimit: 120000,
+					// FIXME (wojtek): Take this value from Network.InitialGasPrice() once Milad integrates it into crust
+					GasPrice: big.NewInt(1500),
+				},
 				Sender:   sender,
 				Receiver: sender,
 				Balance:  cored.Balance{Denom: "core", Amount: big.NewInt(1)},

--- a/tests/bank/gas.go
+++ b/tests/bank/gas.go
@@ -21,18 +21,26 @@ var maxMemo = strings.Repeat("-", 256) // cosmos sdk is configured to accept max
 // TestTransferMaximumGas checks that transfer does not take more gas than assumed
 func TestTransferMaximumGas(chain cored.Cored, numOfTransactions int) (testing.PrepareFunc, testing.RunFunc) {
 	const margin = 1.5
-	const maxGasAssumed = 100000 // set it to 50%+ higher than maximum observed value
+	// FIXME (wojtek): Take this value from Network.TxBankSendGas() once Milad integrates it into crust
+	const maxGasAssumed = 120000 // set it to 50%+ higher than maximum observed value
 
-	amount, ok := big.NewInt(0).SetString("100000000000000000000", 10)
+	amount, ok := big.NewInt(0).SetString("100000000000000000000000000000000000", 10)
 	if !ok {
 		panic("invalid amount")
 	}
 
+	// FIXME (wojciech): Compute fee based on Network once Milad integrates it into crust
+	fees, ok := big.NewInt(0).SetString("180000000", 10)
+	if !ok {
+		panic("invalid amount")
+	}
+	fees.Mul(fees, big.NewInt(int64(numOfTransactions)))
+
 	var wallet1, wallet2 cored.Wallet
 
 	return func(ctx context.Context) error {
-			wallet1 = chain.AddWallet(fmt.Sprintf("%score", amount))
-			wallet2 = chain.AddWallet("1core")
+			wallet1 = chain.AddWallet(fmt.Sprintf("%score", big.NewInt(0).Add(fees, amount)))
+			wallet2 = chain.AddWallet(fmt.Sprintf("%score", fees))
 			return nil
 		},
 		func(ctx context.Context, t *testing.T) {
@@ -49,8 +57,10 @@ func TestTransferMaximumGas(chain cored.Cored, numOfTransactions int) (testing.P
 			var maxGasUsed int64
 			toSend := cored.Balance{Denom: "core", Amount: amount}
 			for i, sender, receiver := numOfTransactions, wallet1, wallet2; i >= 0; i, sender, receiver = i-1, receiver, sender {
-				gasUsed, err := sendAndReturnGasUsed(ctx, client, sender, receiver, toSend)
-				require.NoError(t, err)
+				gasUsed, err := sendAndReturnGasUsed(ctx, client, sender, receiver, toSend, maxGasAssumed)
+				if !assert.NoError(t, err) {
+					break
+				}
 
 				if gasUsed > maxGasUsed {
 					maxGasUsed = gasUsed
@@ -62,12 +72,18 @@ func TestTransferMaximumGas(chain cored.Cored, numOfTransactions int) (testing.P
 		}
 }
 
-func sendAndReturnGasUsed(ctx context.Context, client cored.Client, sender, receiver cored.Wallet, toSend cored.Balance) (int64, error) {
-	txBytes, err := client.PrepareTxBankSend(ctx, cored.TxBankSendData{
+func sendAndReturnGasUsed(ctx context.Context, client cored.Client, sender, receiver cored.Wallet, toSend cored.Balance, gasLimit uint64) (int64, error) {
+	txBytes, err := client.PrepareTxBankSend(ctx, cored.TxBankSendInput{
+		Signing: cored.SigningInput{
+			Signer:   sender,
+			GasLimit: gasLimit,
+			// FIXME (wojtek): Take this value from Network.InitialGasPrice() once Milad integrates it into crust
+			GasPrice: big.NewInt(1500),
+			Memo:     maxMemo, // memo is set to max length here to charge as much gas as possible
+		},
 		Sender:   sender,
 		Receiver: receiver,
 		Balance:  toSend,
-		Memo:     maxMemo, // memo is set to max length here to charge as much gas as possible
 	})
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Cored will require minimum fees soon. This PR adjusts `crust` to support that requirement:
- client allows to specify gas limit and gas price for transaction
- wallets are funded appropriately so all the operations (ping-pong, zstress and integration tests) have enough funds to send transactions
- once `cored` starts to require fees, additional integration test will be added to `crust` to verify that transaction not providing enough fee fails