### PR TITLE
Fix path to bin directory

### DIFF
--- a/cmd/znet/main.go
+++ b/cmd/znet/main.go
@@ -91,7 +91,9 @@ func main() {
 }
 
 func addBinDirFlag(cmd *cobra.Command, configF *infra.ConfigFactory) {
-	cmd.Flags().StringVar(&configF.BinDir, "bin-dir", defaultString("CRUST_ZNET_BIN_DIR", filepath.Dir(filepath.Dir(must.String(filepath.EvalSymlinks(must.String(os.Executable())))))), "Path to directory where executables exist")
+	cmd.Flags().StringVar(&configF.BinDir, "bin-dir", defaultString("CRUST_ZNET_BIN_DIR",
+		filepath.Dir(filepath.Dir(must.String(filepath.EvalSymlinks(must.String(os.Executable())))))),
+		"Path to directory where executables exist")
 }
 
 func addModeFlag(cmd *cobra.Command, c *ioc.Container, configF *infra.ConfigFactory) {

--- a/cmd/znet/main.go
+++ b/cmd/znet/main.go
@@ -91,7 +91,7 @@ func main() {
 }
 
 func addBinDirFlag(cmd *cobra.Command, configF *infra.ConfigFactory) {
-	cmd.Flags().StringVar(&configF.BinDir, "bin-dir", defaultString("CRUST_ZNET_BIN_DIR", filepath.Join(filepath.Dir(filepath.Dir(must.String(filepath.EvalSymlinks(must.String(os.Executable()))))), ".cache/docker")), "Path to directory where executables exist")
+	cmd.Flags().StringVar(&configF.BinDir, "bin-dir", defaultString("CRUST_ZNET_BIN_DIR", filepath.Dir(filepath.Dir(must.String(filepath.EvalSymlinks(must.String(os.Executable())))))), "Path to directory where executables exist")
 }
 
 func addModeFlag(cmd *cobra.Command, c *ioc.Container, configF *infra.ConfigFactory) {

--- a/infra/apps/cored/cored.go
+++ b/infra/apps/cored/cored.go
@@ -186,7 +186,7 @@ func (c Cored) HealthCheck(ctx context.Context) error {
 // Deployment returns deployment of cored
 func (c Cored) Deployment() infra.Deployment {
 	deployment := infra.Binary{
-		BinPath: c.config.BinDir + "/cored",
+		BinPath: c.config.BinDir + "/.cache/docker/cored",
 		AppBase: infra.AppBase{
 			Name: c.Name(),
 			Info: c.appInfo,


### PR DESCRIPTION
Otherwise cored-client wrapper script calls docker-built binary instead of the locally-built one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coreumfoundation/crust/25)
<!-- Reviewable:end -->
