### PR TITLE
We require go 1.17 to build `crust`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Prerequisites
 To use `crust` you need:
-- `go 1.16` or newer
+- `go 1.17` or newer
 - `tmux`
 - `docker`
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coreumfoundation/crust/55)
<!-- Reviewable:end -->
