### PR TITLE
Remove hacky nolints related to gofmt of go 1.19

### DIFF
--- a/infra/apps/blockexplorer/bdjuno.go
+++ b/infra/apps/blockexplorer/bdjuno.go
@@ -5,6 +5,6 @@ import (
 )
 
 // BDJunoConfigTemplate contains bdjuno configuration template
-//nolint:gofmt,goimports // Looks like gofmt linter has a bug and it produces error because of go:embed
+//
 //go:embed bdjuno/config/config.tmpl.yaml
 var BDJunoConfigTemplate string

--- a/infra/apps/blockexplorer/hasura.go
+++ b/infra/apps/blockexplorer/hasura.go
@@ -5,6 +5,6 @@ import (
 )
 
 // HasuraMetadataTemplate contains hasura metadata template
-//nolint:gofmt,goimports // Looks like gofmt linter has a bug and it produces error because of go:embed
+//
 //go:embed hasura/metadata/metadata.tmpl.json
 var HasuraMetadataTemplate string


### PR DESCRIPTION
`gofmt` now puts an empty line in the comment before a directive

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coreumfoundation/crust/64)
<!-- Reviewable:end -->
