### PR TITLE
`znet`: Integrate `faucet`

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -14,7 +14,7 @@ import (
 // FIXME (wojtek): rearrange functions here and in `git` in product-specific subpackages
 
 func buildAll(deps build.DepsFunc) {
-	deps(buildCored, buildZNet, buildAllIntegrationTests)
+	deps(buildCored, buildFaucet, buildZNet, buildAllIntegrationTests)
 }
 
 func buildAllIntegrationTests(deps build.DepsFunc) {
@@ -45,6 +45,18 @@ func buildCored(ctx context.Context, deps build.DepsFunc) error {
 	return golang.BuildInDocker(ctx, golang.BinaryBuildConfig{
 		PackagePath:    "../coreum/cmd/cored",
 		BinOutputPath:  "bin/.cache/docker/cored",
+		CGOEnabled:     true,
+		Tags:           []string{"muslc"},
+		LinkStatically: true,
+	})
+}
+
+func buildFaucet(ctx context.Context, deps build.DepsFunc) error {
+	deps(golang.EnsureGo, git.EnsureFaucetRepo)
+
+	return golang.BuildInDocker(ctx, golang.BinaryBuildConfig{
+		PackagePath:    "../faucet",
+		BinOutputPath:  "bin/.cache/docker/faucet",
 		CGOEnabled:     true,
 		Tags:           []string{"muslc"},
 		LinkStatically: true,

--- a/build/index.go
+++ b/build/index.go
@@ -10,6 +10,7 @@ var Commands = map[string]interface{}{
 	"build":                   buildAll,
 	"build/crust":             buildCrust,
 	"build/cored":             buildCored,
+	"build/faucet":            buildFaucet,
 	"build/znet":              buildZNet,
 	"build/integration-tests": buildAllIntegrationTests,
 	"lint":                    golang.Lint,

--- a/infra/apps/cored/cored.go
+++ b/infra/apps/cored/cored.go
@@ -68,7 +68,7 @@ func New(config Config) Cored {
 		config.Network.AddGenesisTx(tx)
 	}
 
-	cored := Cored{
+	return Cored{
 		config:              config,
 		nodeID:              NodeID(nodePublicKey),
 		nodePrivateKey:      nodePrivateKey,
@@ -76,7 +76,6 @@ func New(config Config) Cored {
 		mu:                  &sync.RWMutex{},
 		walletKeys:          config.Wallets,
 	}
-	return cored
 }
 
 // Cored represents cored

--- a/infra/apps/faucet/faucet.go
+++ b/infra/apps/faucet/faucet.go
@@ -1,0 +1,126 @@
+package faucet
+
+import (
+	"context"
+	"encoding/hex"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/CoreumFoundation/coreum-tools/pkg/must"
+	"github.com/CoreumFoundation/coreum-tools/pkg/retry"
+	"github.com/CoreumFoundation/coreum/app"
+	"github.com/CoreumFoundation/coreum/pkg/types"
+	"github.com/CoreumFoundation/crust/infra"
+	"github.com/CoreumFoundation/crust/infra/apps/cored"
+	"github.com/CoreumFoundation/crust/infra/targets"
+)
+
+const (
+	// AppType is the type of faucet application
+	AppType infra.AppType = "faucet"
+
+	// DefaultPort is the default port faucet listens on for client connections
+	DefaultPort = 8090
+)
+
+// Config stores faucet app config
+type Config struct {
+	Name       string
+	HomeDir    string
+	BinDir     string
+	ChainID    app.ChainID
+	AppInfo    *infra.AppInfo
+	Port       int
+	PrivateKey types.Secp256k1PrivateKey
+	Cored      cored.Cored
+}
+
+// New creates new faucet app
+func New(config Config) Faucet {
+	return Faucet{
+		config: config,
+	}
+}
+
+// Faucet represents faucet
+type Faucet struct {
+	config Config
+}
+
+// Type returns type of application
+func (f Faucet) Type() infra.AppType {
+	return AppType
+}
+
+// Name returns name of app
+func (f Faucet) Name() string {
+	return f.config.Name
+}
+
+// Port returns port used by the application
+func (f Faucet) Port() int {
+	return f.config.Port
+}
+
+// Info returns deployment info
+func (f Faucet) Info() infra.DeploymentInfo {
+	return f.config.AppInfo.Info()
+}
+
+// HealthCheck checks if cored chain is ready to accept transactions
+func (f Faucet) HealthCheck(ctx context.Context) error {
+	if f.config.AppInfo.Info().Status != infra.AppStatusRunning {
+		return retry.Retryable(errors.Errorf("faucet hasn't started yet"))
+	}
+
+	statusURL := url.URL{Scheme: "http", Host: infra.JoinNetAddr("", f.Info().HostFromHost, f.config.Port), Path: "/api/faucet/v1/status"}
+	req := must.HTTPRequest(http.NewRequestWithContext(ctx, http.MethodGet, statusURL.String(), nil))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return retry.Retryable(errors.WithStack(err))
+	}
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return retry.Retryable(errors.Errorf("health check failed, status code: %d", resp.StatusCode))
+	}
+	return nil
+}
+
+// Deployment returns deployment of cored
+func (f Faucet) Deployment() infra.Deployment {
+	return infra.Binary{
+		BinPath: f.config.BinDir + "/.cache/docker/faucet",
+		AppBase: infra.AppBase{
+			Name: f.Name(),
+			Info: f.config.AppInfo,
+			ArgsFunc: func() []string {
+				return []string{
+					"--address", infra.JoinNetAddrIP("", net.IPv4zero, f.config.Port),
+					"--chain-id", string(f.config.ChainID),
+					"--key-path", filepath.Join(targets.AppHomeDir, "key"),
+					"--node", infra.JoinNetAddr("", f.config.Cored.Info().HostFromContainer, f.config.Cored.Ports().RPC),
+					"--log-format", "yaml",
+				}
+			},
+			Ports: map[string]int{
+				"server": f.config.Port,
+			},
+			Requires: infra.Prerequisites{
+				Timeout: 20 * time.Second,
+				Dependencies: []infra.HealthCheckCapable{
+					f.config.Cored,
+				},
+			},
+			PrepareFunc: func() error {
+				return errors.WithStack(os.WriteFile(filepath.Join(f.config.HomeDir, "key"), []byte(hex.EncodeToString(f.config.PrivateKey)), 0o400))
+			},
+		},
+	}
+}

--- a/infra/apps/faucet/key.go
+++ b/infra/apps/faucet/key.go
@@ -1,0 +1,4 @@
+package faucet
+
+// PrivateKeyMnemonic is mnemonic of private key used by faucet to broadcast requested transfers
+const PrivateKeyMnemonic = "pitch basic bundle cause toe sound warm love town crucial divorce shell olympic convince scene middle garment glimpse narrow during fix fruit suffer honey"

--- a/pkg/znet/mode.go
+++ b/pkg/znet/mode.go
@@ -13,15 +13,27 @@ func DevMode(appF *apps.Factory) infra.Mode {
 	must.OK(err)
 	node := coredNodes[0].(cored.Cored)
 
+	faucet, err := appF.Faucet("faucet", node)
+	must.OK(err)
+
 	var mode infra.Mode
 	mode = append(mode, coredNodes...)
+	mode = append(mode, faucet)
 	mode = append(mode, appF.BlockExplorer("explorer", node)...)
 	return mode
 }
 
 // TestMode returns environment used for testing
 func TestMode(appF *apps.Factory) infra.Mode {
-	mode, err := appF.CoredNetwork("coretest", 3, 0)
+	coredNodes, err := appF.CoredNetwork("coretest", 3, 0)
 	must.OK(err)
+	node := coredNodes[0].(cored.Cored)
+
+	faucet, err := appF.Faucet("faucet", node)
+	must.OK(err)
+
+	var mode infra.Mode
+	mode = append(mode, coredNodes...)
+	mode = append(mode, faucet)
 	return mode
 }


### PR DESCRIPTION
To test faucet in `znet`:

```
$ znet start
$ coredev-00 q bank balances devcore1lyru5pvjymya9xq0rsg406fss45sama8e9dqrs
$ curl -X POST http://localhost:8090/api/faucet/v1/send-money -H "Content-Type: application/json" -d '{"address": "devcore1lyru5pvjymya9xq0rsg406fss45sama8e9dqrs"}' 
$ coredev-00 q bank balances devcore1lyru5pvjymya9xq0rsg406fss45sama8e9dqrs
```
You should see additional tokens available on the account