### PR TITLE
Adjust crust validator delegation to customParams.Staking.MinimumSelfDelegation

### DIFF
--- a/infra/apps/cored/cored.go
+++ b/infra/apps/cored/cored.go
@@ -37,12 +37,8 @@ import (
 	"github.com/CoreumFoundation/crust/infra/targets"
 )
 
-const (
-	// AppType is the type of cored application.
-	AppType infra.AppType = "cored"
-
-	validatorSelfDelegatedAmount = 20_000_000_000
-)
+// AppType is the type of cored application.
+const AppType infra.AppType = "cored"
 
 // Config stores cored app config.
 type Config struct {
@@ -79,7 +75,7 @@ func New(cfg Config) Cored {
 		stakerPrivKey, err := PrivateKeyFromMnemonic(cfg.StakerMnemonic)
 		must.OK(err)
 
-		minimumSelfDelegation := sdk.NewInt64Coin(cfg.Network.Denom(), validatorSelfDelegatedAmount)
+		minimumSelfDelegation := sdk.NewInt64Coin(cfg.Network.Denom(), 20_000_000_000) // 20k core
 
 		// We have integration tests adding new validators with min self delegation, and then we kill them when test completes.
 		// So if those tests run together and create validators having 33% of voting power, then killing them will halt the chain.


### PR DESCRIPTION
# Issue:
https://app.clickup.com/t/862hxz3vw

# Testing:
## `crust znet test` 
All tests succeeded 

## Manual
`crust znet start --profiles=3cored`:
```
cored q staking validator devcorevaloper17wep7cp7kux5maqr5mrqd7we3ndnz97rzdxlvn --chain-id=coreum-devnet-1

# output:
  min_self_delegation: "20000000000"
...
  status: BOND_STATUS_BONDED
  tokens: "1000000000000"

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/172)
<!-- Reviewable:end -->
