### PR TITLE
Make both v2 & v3 binaries work inside znet

### DIFF
--- a/build/coreum/images.go
+++ b/build/coreum/images.go
@@ -67,6 +67,7 @@ func ensureReleasedBinaries(ctx context.Context, deps build.DepsFunc) error {
 	for _, binaryTool := range []tools.Name{
 		tools.CoredV100,
 		tools.CoredV200,
+		tools.CoredV202,
 	} {
 		if err := tools.Ensure(ctx, binaryTool, tools.PlatformDockerLocal); err != nil {
 			return err

--- a/build/go.mod
+++ b/build/go.mod
@@ -4,6 +4,8 @@ module github.com/CoreumFoundation/crust/build
 // Build tool installs newer go, but the tool itself must be built using a preexisting version.
 go 1.19
 
+replace github.com/CoreumFoundation/coreum/v2 => ../../coreum/
+
 require (
 	github.com/CoreumFoundation/coreum-tools v0.4.1-0.20230627094203-821c6a4eebab
 	github.com/CoreumFoundation/coreum/v2 v2.0.3-0.20230810074019-b41dba895971

--- a/build/tools/tools.go
+++ b/build/tools/tools.go
@@ -39,6 +39,7 @@ const (
 	Hermes                Name = "hermes"
 	CoredV100             Name = "cored-v1.0.0"
 	CoredV200             Name = "cored-v2.0.0"
+	CoredV202             Name = "cored-v2.0.2"
 	Protoc                Name = "protoc"
 	ProtocGenDoc          Name = "protoc-gen-doc"
 	ProtocGenGRPCGateway  Name = "protoc-gen-grpc-gateway"
@@ -307,6 +308,26 @@ var tools = []Tool{
 				Hash: "sha256:c082eeebbc206633f1b71ef9c16a7f390f5ea5b27ce06c735ed7a632f38b5891",
 				Binaries: map[string]string{
 					"bin/cored-v2.0.0": "cored-linux-arm64",
+				},
+			},
+		},
+	},
+	BinaryTool{
+		Name:    CoredV200,
+		Version: "v2.0.2",
+		Sources: Sources{
+			PlatformDockerAMD64: {
+				URL:  "https://github.com/CoreumFoundation/coreum/releases/download/v2.0.2/cored-linux-amd64",
+				Hash: "sha256:3facf55f7ff795719f68b9bcf76ea08262bc7c9e9cd735c660257ba73678250e",
+				Binaries: map[string]string{
+					"bin/cored-v2.0.2": "cored-linux-amd64",
+				},
+			},
+			PlatformDockerARM64: {
+				URL:  "https://github.com/CoreumFoundation/coreum/releases/download/v2.0.2/cored-linux-arm64",
+				Hash: "sha256:35e261eb3b87c833c30174e6b8667a6155f5962441275d443157e209bbb0bf0d",
+				Binaries: map[string]string{
+					"bin/cored-v2.0.2": "cored-linux-arm64",
 				},
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.20
 
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
+replace github.com/CoreumFoundation/coreum/v2 => ../coreum/
+
 require (
 	cosmossdk.io/math v1.0.1
 	github.com/CoreumFoundation/coreum-tools v0.4.1-0.20230627094203-821c6a4eebab
@@ -16,6 +18,8 @@ require (
 	github.com/prometheus/common v0.42.0
 	github.com/samber/lo v1.38.1
 	github.com/spf13/cobra v1.7.0
+	github.com/tidwall/gjson v1.16.0
+	github.com/tidwall/sjson v1.2.5
 	go.uber.org/zap v1.23.0
 	google.golang.org/grpc v1.57.0
 )
@@ -157,6 +161,8 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tendermint/go-amino v0.16.0 // indirect
 	github.com/tidwall/btree v1.6.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/ulikunitz/xz v0.5.11 // indirect
 	github.com/zondax/hid v0.9.1 // indirect
 	github.com/zondax/ledger-go v0.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,6 @@ github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQ
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/CoreumFoundation/coreum-tools v0.4.1-0.20230627094203-821c6a4eebab h1:XPcSzlQ06tor/py1LkEM9FX70LIeDWB++vLuAO6eAYI=
 github.com/CoreumFoundation/coreum-tools v0.4.1-0.20230627094203-821c6a4eebab/go.mod h1:VD93vCHkxYaT/RhOesXTFgd/GQDW54tr0BqGi5JU1c0=
-github.com/CoreumFoundation/coreum/v2 v2.0.3-0.20230810074019-b41dba895971 h1:yJN1IGXinoiEAkAIz/8hCGynONkUkp+F2f0U1L2+OFw=
-github.com/CoreumFoundation/coreum/v2 v2.0.3-0.20230810074019-b41dba895971/go.mod h1:MzFJLuwpp1bXxPzVJzjpOOe4hsGi5ZVoFk9DpsaLQ4g=
 github.com/CosmWasm/wasmd v0.41.0 h1:fmwxSbwb50zZDcBaayYFRLIaSFca+EFld1WOaQi49jg=
 github.com/CosmWasm/wasmd v0.41.0/go.mod h1:0Sds1q2IsPaTN1gHa3BNOYcUFgtGvxH7CXEXPgoihns=
 github.com/CosmWasm/wasmvm v1.3.0 h1:x12X4bKlUPS7TT9QQP45+fJo2sp30GEbiSSgb9jsec8=
@@ -1014,6 +1012,15 @@ github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2l
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
 github.com/tidwall/btree v1.6.0 h1:LDZfKfQIBHGHWSwckhXI0RPSXzlo+KYdjK7FWSqOzzg=
 github.com/tidwall/btree v1.6.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.16.0 h1:SyXa+dsSPpUlcwEDuKuEBJEz5vzTvOea+9rjyYodQFg=
+github.com/tidwall/gjson v1.16.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=

--- a/pkg/znet/commands.go
+++ b/pkg/znet/commands.go
@@ -299,7 +299,7 @@ func coredVersionToGenesisTemplate(coredVersion string) (string, error) {
 	switch coredVersion {
 	case "", "v3.0.0":
 		return coreumconfig.GenesisV3Template, nil
-	case "v2.0.0":
+	case "v2.0.0", "v2.0.2":
 		return coreumconfig.GenesisV2Template, nil
 	case "v1.0.0":
 		return coreumconfig.GenesisV1Template, nil


### PR DESCRIPTION
# Description

Before this PR we had issue that `crust znet` is not able to start with any cored version other than from branch `v0.47-migration-v2` because of different internal genesis structure. In this PR I manually edit genesis generated by coreum for v2. Please note that this is temporary solution intended to speed up v47 branch merge. As a long term solution we should solve genesis problem differently.

Related coreum PR: https://github.com/CoreumFoundation/coreum/pull/617

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.
