### PR TITLE
restore upgrade test profile

### DIFF
--- a/cmd/znet/main.go
+++ b/cmd/znet/main.go
@@ -104,7 +104,7 @@ func testCmd(ctx context.Context, configF *infra.ConfigFactory, cmdF *znet.CmdFa
 		Use:   "test",
 		Short: "Runs integration tests for all repos",
 		RunE: cmdF.Cmd(func() error {
-			if lo.Contains(configF.TestGroups, apps.TestGroupCoreumIBC) || len(configF.TestGroups) == 0 {
+			if lo.Some(configF.TestGroups, []string{apps.TestGroupCoreumIBC, apps.TestGroupCoreumUpgrade}) || len(configF.TestGroups) == 0 {
 				configF.Profiles = []string{apps.ProfileIntegrationTestsIBC}
 			} else {
 				configF.Profiles = []string{apps.ProfileIntegrationTestsModules}


### PR DESCRIPTION
# Description
This profile restores the profile used for upgrade tests, so ibc will be started for it. that helps us to separate upgrade tests and ibc tests in CI for coreum. 
# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/282)
<!-- Reviewable:end -->
