### PR TITLE
Extend voting period to 10 seconds

### DIFF
--- a/infra/apps/cored/config.go
+++ b/infra/apps/cored/config.go
@@ -52,7 +52,7 @@ func NetworkConfig(genesisTemplate string, blockTimeIota time.Duration) (config.
 			GovConfig: config.GovConfig{
 				ProposalConfig: config.GovProposalConfig{
 					MinDepositAmount: "1000",
-					VotingPeriod:     (time.Second * 5).String(),
+					VotingPeriod:     (time.Second * 10).String(),
 				},
 			},
 			CustomParamsConfig: config.CustomParamsConfig{


### PR DESCRIPTION
# Description

We used 5-second voting period in integration tests. From time to time we have observed failures on voting, saying that voting period passed for the proposal. Let's try how 10 seconds work.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/285)
<!-- Reviewable:end -->
