### PR TITLE
Automatically restart Hermes relayer on cored version change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
             command: |
               crust build/integration-tests/coreum/upgrade build/integration-tests/coreum/ibc images
               crust znet test --cored-version=v2.0.2 --test-groups=coreum-upgrade,coreum-ibc --timeout-commit 1s
-              crust znet test --test-groups=coreum-ibc --timeout-commit 1s
             go-cache: true
             wasm-cache: true
             linter-cache: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,7 @@ jobs:
           - ci_step: "integration tests coreum-upgrade & coreum-ibc"
             command: |
               crust build/integration-tests/coreum/upgrade build/integration-tests/coreum/ibc images
-              crust znet test --cored-version=v2.0.2 --test-groups=coreum-upgrade --timeout-commit 1s
-              docker restart znet-ibc-hermes-gaiad
+              crust znet test --cored-version=v2.0.2 --test-groups=coreum-upgrade,coreum-ibc --timeout-commit 1s
               crust znet test --test-groups=coreum-ibc --timeout-commit 1s
             go-cache: true
             wasm-cache: true

--- a/build/docker/basic/Dockerfile.tmpl
+++ b/build/docker/basic/Dockerfile.tmpl
@@ -1,5 +1,9 @@
 FROM {{ .From }}
 
+{{ if .Run }}
+RUN {{ .Run }}
+{{ end }}
+
 COPY {{ .Binary }} /{{ .Binary }}
 
 ENTRYPOINT ["/{{ .Binary }}"]

--- a/build/docker/basic/template.go
+++ b/build/docker/basic/template.go
@@ -19,6 +19,9 @@ type Data struct {
 
 	// Binary is the name of binary file to copy from build context
 	Binary string
+
+	// Run is an extra command to be run during image build. RUN directive will be used to execute it.
+	Run string
 }
 
 // Execute executes dockerfile template and returns complete dockerfile.

--- a/build/hermes/image.go
+++ b/build/hermes/image.go
@@ -30,6 +30,7 @@ func BuildDockerImage(ctx context.Context, deps build.DepsFunc) error {
 	dockerfile, err := dockerbasic.Execute(dockerbasic.Data{
 		From:   docker.UbuntuImage,
 		Binary: binaryPath,
+		Run:    "apt update && apt install curl jq -y",
 	})
 	if err != nil {
 		return err

--- a/infra/apps/hermes/run.tmpl
+++ b/infra/apps/hermes/run.tmpl
@@ -19,6 +19,35 @@ if [ ! -d "$RELAYER_KEYS_PATH" ]; then
 
 fi
 
-
 echo "Starting the relayer."
-hermes start
+hermes start &
+
+# Capture the process ID to kill it later if needed
+PID=$!
+
+INITIAL_VERSION=$(curl -s {{ .CoreumRPCURL }}/abci_info\? | jq '.result.response.version')
+
+# If initial version is empty kill the process.
+if [ -z "$INITIAL_VERSION" ]; then
+  echo "Failed to fetch the initial API version. Exiting."
+  kill $PID
+  exit 1
+fi
+
+while true; do
+  sleep 3
+
+  CURRENT_VERSION=$(curl -s {{ .CoreumRPCURL }}/abci_info\? | jq '.result.response.version')
+
+  # If fetching of version fails, skip this iteration
+  if [ -z "$CURRENT_VERSION" ]; then
+    echo "API version is not available. Skipping this check."
+    continue
+  fi
+
+  if [ "$INITIAL_VERSION" != "$CURRENT_VERSION" ]; then
+    kill $PID
+    echo "API version changed from $INITIAL_VERSION to $CURRENT_VERSION. Process killed."
+    exit 1
+  fi
+done


### PR DESCRIPTION
# Description

Since in master `cored` we migrate to IBC v7 and Hermes has this bug https://github.com/informalsystems/hermes/issues/3579 when it is not able to detect IBC version change we have to restart the relayer on cored version change.
This PR adds functionality to automatically restart Hermes if cored version returned by API changes.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/286)
<!-- Reviewable:end -->
