### PR TITLE
Disable `interfacebloat` linter

### DIFF
--- a/build/.golangci.yaml
+++ b/build/.golangci.yaml
@@ -58,6 +58,7 @@ linters:
     - wsl
     - depguard
     - musttag
+    - interfacebloat
     # deprecated:
     - golint
     - interfacer


### PR DESCRIPTION
# Description

`interfacebloat` produces messages like `the interface has more than 10 methods: 11 (interfacebloat)`

This is useless, if we need bigger interface, we need it and that's it.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/293)
<!-- Reviewable:end -->
