### PR TITLE
Disable `dupl` linter in tests

### DIFF
--- a/build/.golangci.yaml
+++ b/build/.golangci.yaml
@@ -22,6 +22,7 @@ issues:
     - path: _test\.go
       linters:
         - funlen
+        - dupl
 
 linters:
   enable-all: true


### PR DESCRIPTION
# Description

We don't care about code duplication in tests and we always add `//nolint:dupl` annotation whenever it is reported.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/295)
<!-- Reviewable:end -->
