### PR TITLE
Use --p2p.seeds instead of --p2p.persistent_peers for the crust znet

### DIFF
--- a/infra/apps/cored/cored.go
+++ b/infra/apps/cored/cored.go
@@ -295,7 +295,7 @@ func (c Cored) Deployment() infra.Deployment {
 			}
 			if c.config.RootNode != nil {
 				args = append(args,
-					"--p2p.persistent_peers", c.config.RootNode.NodeID()+"@"+infra.JoinNetAddr("", c.config.RootNode.Info().HostFromContainer, c.config.RootNode.Config().Ports.P2P),
+					"--p2p.seeds", c.config.RootNode.NodeID()+"@"+infra.JoinNetAddr("", c.config.RootNode.Info().HostFromContainer, c.config.RootNode.Config().Ports.P2P),
 				)
 			}
 


### PR DESCRIPTION
# Description

Use --p2p.seeds instead of --p2p.persistent_peers for the crust znet. That change is required to be able to connect to the running znet.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/296)
<!-- Reviewable:end -->
