### PR TITLE
Use non-used local branch name when cloning

### DIFF
--- a/build/coreum/generate-proto-breaking.go
+++ b/build/coreum/generate-proto-breaking.go
@@ -31,7 +31,7 @@ func breakingProto(ctx context.Context, deps build.DepsFunc) error {
 	}
 	defer os.RemoveAll(masterDir) //nolint:errcheck // error doesn't matter
 
-	if err := git.Clone(ctx, masterDir, repoPath, "master"); err != nil {
+	if err := git.Clone(ctx, masterDir, repoPath, "crust/proto-breaking", "master"); err != nil {
 		return err
 	}
 

--- a/build/git/git.go
+++ b/build/git/git.go
@@ -111,7 +111,7 @@ func VersionFromTag(ctx context.Context, repoPath string) (string, error) {
 }
 
 // Clone clones specific branch from repo to another directory.
-func Clone(ctx context.Context, dstDir, srcDir string, branch string) error {
+func Clone(ctx context.Context, dstDir, srcDir string, localBranch, remoteBranch string) error {
 	srcAbs, err := filepath.Abs(srcDir)
 	if err != nil {
 		return errors.WithStack(err)
@@ -126,10 +126,10 @@ func Clone(ctx context.Context, dstDir, srcDir string, branch string) error {
 		return errors.WithStack(err)
 	}
 
-	cmd1 := exec.Command("git", "fetch", "origin", branch+":"+branch)
+	cmd1 := exec.Command("git", "fetch", "origin", remoteBranch+":"+localBranch)
 	cmd1.Dir = srcDir
 
-	cmd2 := exec.Command("git", "clone", "--single-branch", "--no-tags", "-b", branch, srcAbs, ".")
+	cmd2 := exec.Command("git", "clone", "--single-branch", "--no-tags", "-b", localBranch, srcAbs, ".")
 	cmd2.Dir = dstAbs
 
 	return libexec.Exec(ctx, cmd1, cmd2)


### PR DESCRIPTION
# Description

When coreum linter is executed for `master` branch error is returned when we try to clone that branch. This PR fixes this by using a crust-specific local branch name.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/298)
<!-- Reviewable:end -->
