### PR TITLE
Ensure go is installed first when running `crust setup` command

### DIFF
--- a/build/tools/tools.go
+++ b/build/tools/tools.go
@@ -662,6 +662,7 @@ type Sources map[Platform]Source
 
 // InstallAll installs all the toolsMap.
 func InstallAll(ctx context.Context, deps build.DepsFunc) error {
+	Ensure(ctx, Go, PlatformLocal)
 	for toolName := range toolsMap {
 		tool := toolsMap[toolName]
 		if tool.IsLocal() {

--- a/build/tools/tools.go
+++ b/build/tools/tools.go
@@ -662,7 +662,9 @@ type Sources map[Platform]Source
 
 // InstallAll installs all the toolsMap.
 func InstallAll(ctx context.Context, deps build.DepsFunc) error {
-	Ensure(ctx, Go, PlatformLocal)
+	if err := Ensure(ctx, Go, PlatformLocal); err != nil {
+		return err
+	}
 	for toolName := range toolsMap {
 		tool := toolsMap[toolName]
 		if tool.IsLocal() {


### PR DESCRIPTION
# Description
when running `crust setup` for the first time, since Go is not installed by crust, it might error out. So installing Go, must be the first command that `crust setup` runs. 
# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/309)
<!-- Reviewable:end -->
