### PR TITLE
Added support for genesis creation via cored CLI

### DIFF
--- a/infra/apps/apps.go
+++ b/infra/apps/apps.go
@@ -49,6 +49,7 @@ func (f *Factory) CoredNetwork(
 	binaryVersion string,
 ) (cored.Cored, []cored.Cored, error) {
 	wallet, networkConfig := cored.NewFundedWallet(f.networkConfig)
+	genesisConfig := cored.GenesisConfigFromNetworkProvider(networkConfig.Provider)
 
 	if validatorCount > wallet.GetStakersMnemonicsCount() {
 		return cored.Cored{}, nil, errors.Errorf(
@@ -83,12 +84,13 @@ func (f *Factory) CoredNetwork(
 		}
 
 		node := cored.New(cored.Config{
-			Name:          name,
-			HomeDir:       filepath.Join(f.config.AppDir, name, string(networkConfig.ChainID())),
-			BinDir:        f.config.BinDir,
-			WrapperDir:    f.config.WrapperDir,
-			NetworkConfig: &networkConfig,
-			AppInfo:       f.spec.DescribeApp(cored.AppType, name),
+			Name:              name,
+			HomeDir:           filepath.Join(f.config.AppDir, name, string(networkConfig.ChainID())),
+			BinDir:            f.config.BinDir,
+			WrapperDir:        f.config.WrapperDir,
+			NetworkConfig:     &networkConfig,
+			GenesisInitConfig: &genesisConfig,
+			AppInfo:           f.spec.DescribeApp(cored.AppType, name),
 			Ports: cored.Ports{
 				RPC:        firstPorts.RPC + portDelta,
 				P2P:        firstPorts.P2P + portDelta,

--- a/infra/apps/apps.go
+++ b/infra/apps/apps.go
@@ -42,6 +42,8 @@ type Factory struct {
 }
 
 // CoredNetwork creates new network of cored nodes.
+//
+//nolint:funlen // breaking down this function will make it less readable.
 func (f *Factory) CoredNetwork(
 	namePrefix string,
 	firstPorts cored.Ports,

--- a/infra/apps/cored/cored.go
+++ b/infra/apps/cored/cored.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -15,6 +16,9 @@ import (
 	"time"
 
 	sdkmath "cosmossdk.io/math"
+	cometbftcrypto "github.com/cometbft/cometbft/crypto"
+	cbfted25519 "github.com/cometbft/cometbft/crypto/ed25519"
+	cmtjson "github.com/cometbft/cometbft/libs/json"
 	cosmosclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/cosmos/cosmos-sdk/crypto"
@@ -27,12 +31,16 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/bank"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/pkg/errors"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+	"go.uber.org/zap"
 
+	"github.com/CoreumFoundation/coreum-tools/pkg/libexec"
+	"github.com/CoreumFoundation/coreum-tools/pkg/logger"
 	"github.com/CoreumFoundation/coreum-tools/pkg/must"
 	"github.com/CoreumFoundation/coreum/v4/app"
 	"github.com/CoreumFoundation/coreum/v4/pkg/client"
@@ -48,11 +56,13 @@ const AppType infra.AppType = "cored"
 
 // Config stores cored app config.
 type Config struct {
-	Name              string
-	HomeDir           string
-	BinDir            string
-	WrapperDir        string
+	Name       string
+	HomeDir    string
+	BinDir     string
+	WrapperDir string
+	// Deprecated: remove after we drop support for cored v3.
 	NetworkConfig     *config.NetworkConfig
+	GenesisInitConfig *GenesisInitConfig
 	AppInfo           *infra.AppInfo
 	Ports             Ports
 	IsValidator       bool
@@ -68,19 +78,83 @@ type Config struct {
 	TimeoutCommit     time.Duration
 }
 
+// GenesisInitConfig is used to pass parameters for genesis creation to cored binary.
+//
+//nolint:tagliatelle
+type GenesisInitConfig struct {
+	ChainID            constant.ChainID    `json:"chain_id"`
+	Denom              string              `json:"denom"`
+	DisplayDenom       string              `json:"display_denom"`
+	AddressPrefix      string              `json:"address_prefix"`
+	GenesisTime        time.Time           `json:"genesis_time"`
+	GovConfig          govConfig           `json:"gov_config"`
+	CustomParamsConfig customParamsConfig  `json:"custom_params_config"`
+	BankBalances       []banktypes.Balance `json:"bank_balances"`
+	Validators         []genesisValidator  `json:"validators"`
+}
+
+//nolint:tagliatelle
+type govConfig struct {
+	MinDeposit   sdk.Coins     `json:"min_deposit"`
+	VotingPeriod time.Duration `json:"voting_period"`
+}
+
+//nolint:tagliatelle
+type customParamsConfig struct {
+	MinSelfDelegation sdkmath.Int `json:"min_self_delegation"`
+}
+
+//nolint:tagliatelle
+type genesisValidator struct {
+	DelegatorMnemonic string                `json:"delegator_mnemonic"`
+	PubKey            cometbftcrypto.PubKey `json:"pub_key"`
+	ValidatorName     string                `json:"validator_name"`
+}
+
+// GenesisConfigFromNetworkProvider creates a new config from the network provider. We should drop usage of
+// the network provider after we stop support for cored v3 binraries, and initialize GenesisInitConfig directly.
+func GenesisConfigFromNetworkProvider(n config.NetworkConfigProvider) GenesisInitConfig {
+	dnp := n.(config.DynamicConfigProvider)
+	minDeposit, ok := sdk.NewIntFromString(dnp.GovConfig.ProposalConfig.MinDepositAmount)
+	if !ok {
+		panic("unable to prase mint deposit amount")
+	}
+	minSelfDelegation, ok := sdk.NewIntFromString(dnp.GovConfig.ProposalConfig.MinDepositAmount)
+	if !ok {
+		panic("unable to prase mint deposit amount")
+	}
+	var bankBalances []banktypes.Balance
+	for _, fa := range dnp.FundedAccounts {
+		bankBalances = append(bankBalances, banktypes.Balance{
+			Address: fa.Address,
+			Coins:   fa.Balances,
+		})
+	}
+
+	return GenesisInitConfig{
+		ChainID:      dnp.ChainID,
+		Denom:        dnp.Denom,
+		DisplayDenom: "devcore",
+		GenesisTime:  dnp.GenesisTime.UTC(),
+		GovConfig: govConfig{
+			MinDeposit: sdk.NewCoins(
+				sdk.NewCoin(dnp.Denom, minDeposit)),
+		},
+		CustomParamsConfig: customParamsConfig{
+			MinSelfDelegation: minSelfDelegation,
+		},
+		BankBalances: bankBalances,
+	}
+}
+
 // New creates new cored app.
 func New(cfg Config) Cored {
 	nodePublicKey, nodePrivateKey, err := ed25519.GenerateKey(rand.Reader)
 	must.OK(err)
 
-	var valPrivateKey ed25519.PrivateKey
+	valPrivateKey := cbfted25519.GenPrivKey()
 	if cfg.IsValidator {
-		var (
-			err          error
-			valPublicKey ed25519.PublicKey
-		)
-		valPublicKey, valPrivateKey, err = ed25519.GenerateKey(rand.Reader)
-		must.OK(err)
+		valPublicKey := valPrivateKey.PubKey()
 
 		stakerPrivKey, err := PrivateKeyFromMnemonic(cfg.StakerMnemonic)
 		must.OK(err)
@@ -96,7 +170,7 @@ func New(cfg Config) Cored {
 		createValidatorTx, err := prepareTxStakingCreateValidator(
 			cfg.NetworkConfig.ChainID(),
 			clientCtx.TxConfig(),
-			valPublicKey,
+			cosmosed25519.PubKey{Key: valPublicKey.Bytes()},
 			stakerPrivKey,
 			stake,
 			minimumSelfDelegation.Amount,
@@ -104,13 +178,18 @@ func New(cfg Config) Cored {
 		must.OK(err)
 		networkProvider := cfg.NetworkConfig.Provider.(config.DynamicConfigProvider)
 		cfg.NetworkConfig.Provider = networkProvider.WithGenesisTx(createValidatorTx)
+		cfg.GenesisInitConfig.Validators = append(cfg.GenesisInitConfig.Validators, genesisValidator{
+			DelegatorMnemonic: cfg.StakerMnemonic,
+			PubKey:            valPublicKey,
+			ValidatorName:     NodeID(nodePublicKey),
+		})
 	}
 
 	return Cored{
 		config:              cfg,
 		nodeID:              NodeID(nodePublicKey),
 		nodePrivateKey:      nodePrivateKey,
-		validatorPrivateKey: valPrivateKey,
+		validatorPrivateKey: valPrivateKey.Bytes(),
 		mu:                  &sync.RWMutex{},
 		importedMnemonics:   cfg.ImportedMnemonics,
 	}
@@ -120,7 +199,7 @@ func New(cfg Config) Cored {
 func prepareTxStakingCreateValidator(
 	chainID constant.ChainID,
 	txConfig cosmosclient.TxConfig,
-	validatorPublicKey ed25519.PublicKey,
+	validatorPublicKey cosmosed25519.PubKey,
 	stakerPrivateKey cosmossecp256k1.PrivKey,
 	stakedBalance sdk.Coin,
 	selfDelegation sdkmath.Int,
@@ -137,7 +216,7 @@ func prepareTxStakingCreateValidator(
 	stakerAddress := sdk.AccAddress(stakerPrivateKey.PubKey().Address())
 	msg, err := stakingtypes.NewMsgCreateValidator(
 		sdk.ValAddress(stakerAddress),
-		&cosmosed25519.PubKey{Key: validatorPublicKey},
+		&validatorPublicKey,
 		stakedBalance,
 		stakingtypes.Description{Moniker: stakerAddress.String()},
 		commission,
@@ -358,6 +437,17 @@ func (c Cored) Deployment() infra.Deployment {
 	return deployment
 }
 
+func (c Cored) binaryPath() string {
+	// the path is defined by the build
+	dockerLinuxBinaryPath := filepath.Join(c.config.BinDir, ".cache", "cored", "docker.linux."+runtime.GOARCH, "bin")
+	// by default the binary version is latest, but if `BinaryVersion` is provided we take it as initial
+	binaryPath := filepath.Join(dockerLinuxBinaryPath, "cored")
+	if c.Config().BinaryVersion != "" {
+		binaryPath += "-" + c.Config().BinaryVersion
+	}
+	return binaryPath
+}
+
 func (c Cored) prepare() error {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -398,13 +488,8 @@ func (c Cored) prepare() error {
 	}
 	// the path is defined by the build
 	dockerLinuxBinaryPath := filepath.Join(c.config.BinDir, ".cache", "cored", "docker.linux."+runtime.GOARCH, "bin")
-	// by default the binary version is latest, but if `BinaryVersion` is provided we take it as initial
-	binaryPath := filepath.Join(dockerLinuxBinaryPath, "cored")
-	if c.Config().BinaryVersion != "" {
-		binaryPath += "-" + c.Config().BinaryVersion
-	}
 	if err := copyFile(
-		binaryPath,
+		c.binaryPath(),
 		filepath.Join(c.config.HomeDir, "cosmovisor", "genesis", "bin", "cored"),
 		0o755); err != nil {
 		return err
@@ -458,6 +543,53 @@ func newBasicManager() module.BasicManager {
 
 // SaveGenesis saves json encoded representation of the genesis config into file.
 func (c Cored) SaveGenesis(homeDir string) error {
+	// If genesis template is empty we will use the new method of genesis creation and
+	// use cored binary to create genesis. Otherwise we will use the legacy method and
+	// use template files.
+	if c.config.NetworkConfig.Provider.(config.DynamicConfigProvider).GenesisTemplate != "" {
+		return c.SaveLegacyGenesis(homeDir)
+	}
+
+	if err := os.MkdirAll(homeDir+"/config", 0o700); err != nil {
+		return errors.Wrap(err, "unable to make config directory")
+	}
+	tempFile, err := os.CreateTemp("", "*.json")
+	defer func() {
+		tempFile.Close()
+		os.Remove(tempFile.Name()) //nolint:errcheck
+	}()
+	if err != nil {
+		return err
+	}
+
+	inuptConfig, err := cmtjson.MarshalIndent(c.config.GenesisInitConfig, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	if _, err := tempFile.Write(inuptConfig); err != nil {
+		return err
+	}
+
+	if tempFile.Close(); err != nil {
+		return err
+	}
+
+	fullArgs := []string{
+		"generate-genesis",
+		"--output-path", homeDir + "/config/genesis.json",
+		"--input-path", tempFile.Name(),
+		"--chain-id", string(c.config.GenesisInitConfig.ChainID),
+	}
+
+	return libexec.Exec(
+		logger.WithLogger(context.Background(), zap.NewNop()),
+		exec.Command(c.binaryPath(), fullArgs...),
+	)
+}
+
+// SaveLegacyGenesis saves json encoded representation of the genesis config into file, using templates.
+func (c Cored) SaveLegacyGenesis(homeDir string) error {
 	genDocBytes, err := c.config.NetworkConfig.EncodeGenesis()
 	if err != nil {
 		return err

--- a/infra/apps/hermes/hermes.go
+++ b/infra/apps/hermes/hermes.go
@@ -125,7 +125,7 @@ func (h Hermes) HealthCheck(ctx context.Context) error {
 
 	chainIDs := map[string]struct{}{
 		h.config.PeeredChain.AppConfig().ChainID:                {},
-		string(h.config.Cored.Config().NetworkConfig.ChainID()): {},
+		string(h.config.Cored.Config().NetworkConfig.ChainID()): {}, //nolint:staticcheck
 	}
 
 	for _, metricItem := range metricFamily.GetMetric() {
@@ -207,14 +207,14 @@ func (h Hermes) saveConfigFile() error {
 	}{
 		TelemetryPort: h.config.TelemetryPort,
 
-		CoreumChanID: string(h.config.Cored.Config().NetworkConfig.ChainID()),
+		CoreumChanID: string(h.config.Cored.Config().NetworkConfig.ChainID()), //nolint:staticcheck
 		CoreumRPCURL: infra.JoinNetAddr("http", h.config.Cored.Info().HostFromContainer, h.config.Cored.Config().Ports.RPC),
 		CoreumGRPCURL: infra.JoinNetAddr(
 			"http",
 			h.config.Cored.Info().HostFromContainer,
 			h.config.Cored.Config().Ports.GRPC,
 		),
-		CoreumAccountPrefix: h.config.Cored.Config().NetworkConfig.Provider.GetAddressPrefix(),
+		CoreumAccountPrefix: h.config.Cored.Config().NetworkConfig.Provider.GetAddressPrefix(), //nolint:staticcheck
 		CoreumGasPrice:      lo.Must1(sdk.ParseDecCoin(h.config.Cored.Config().GasPriceStr)),
 
 		PeerChanID: h.config.PeeredChain.AppConfig().ChainID,
@@ -265,7 +265,7 @@ func (h Hermes) saveRunScriptFile() error {
 	}{
 		HomePath: targets.AppHomeDir,
 
-		CoreumChanID:          string(h.config.Cored.Config().NetworkConfig.ChainID()),
+		CoreumChanID:          string(h.config.Cored.Config().NetworkConfig.ChainID()), //nolint:staticcheck
 		CoreumRelayerMnemonic: h.config.CoreumRelayerMnemonic,
 		CoreumRPCURL: infra.JoinNetAddr(
 			"http",

--- a/infra/apps/prometheus/prometheus.go
+++ b/infra/apps/prometheus/prometheus.go
@@ -231,7 +231,7 @@ func (p Prometheus) saveConfigFile() error {
 
 	chainID := ""
 	if len(p.config.CoredNodes) > 0 {
-		chainID = string(p.config.CoredNodes[0].Config().NetworkConfig.ChainID())
+		chainID = string(p.config.CoredNodes[0].Config().NetworkConfig.ChainID()) //nolint:staticcheck
 	}
 	rulesArgs := struct {
 		ChainID string

--- a/pkg/znet/commands.go
+++ b/pkg/znet/commands.go
@@ -113,10 +113,7 @@ func Start(ctx context.Context, config infra.Config, spec *infra.Spec) error {
 		return err
 	}
 
-	genesisTemplate, err := coredVersionToGenesisTemplate(config.CoredVersion)
-	if err != nil {
-		return err
-	}
+	genesisTemplate := coredVersionToGenesisTemplate(config.CoredVersion)
 
 	target := targets.NewDocker(config, spec)
 	networkConfig, err := cored.NetworkConfig(genesisTemplate, config.TimeoutCommit)
@@ -182,10 +179,7 @@ func Test(ctx context.Context, config infra.Config, spec *infra.Spec) error {
 		}
 	}
 
-	genesisTemplate, err := coredVersionToGenesisTemplate(config.CoredVersion)
-	if err != nil {
-		return err
-	}
+	genesisTemplate := coredVersionToGenesisTemplate(config.CoredVersion)
 
 	target := targets.NewDocker(config, spec)
 	networkConfig, err := cored.NetworkConfig(genesisTemplate, config.TimeoutCommit)
@@ -295,15 +289,15 @@ func shellConfig(envName string) (string, string, error) {
 	return shell, promptVar, nil
 }
 
-func coredVersionToGenesisTemplate(coredVersion string) (string, error) {
+func coredVersionToGenesisTemplate(coredVersion string) string {
 	switch coredVersion {
-	case "", "v3.0.0", "v4.0.0":
-		return coreumconfig.GenesisV3Template, nil
+	case "v3.0.0":
+		return coreumconfig.GenesisV3Template
 	case "v2.0.2":
-		return coreumconfig.GenesisV2Template, nil
+		return coreumconfig.GenesisV2Template
 	case "v1.0.0":
-		return coreumconfig.GenesisV1Template, nil
+		return coreumconfig.GenesisV1Template
 	default:
-		return "", errors.Errorf("not supported version of cored: %s", coredVersion)
+		return ""
 	}
 }


### PR DESCRIPTION
# Description
This PR allows crust to generate genesis by interacting with the cored CLI, instead of import template files. We still need to support templates files since earlier versions (v3 and before) depend on it, and we can drop the legacy method after we drop the support to cored v3 binary.
# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/326)
<!-- Reviewable:end -->
