### PR TITLE
Version environments containing installed tools

### DIFF
--- a/build/golang/go.go
+++ b/build/golang/go.go
@@ -138,7 +138,7 @@ func buildInDocker(ctx context.Context, config BinaryBuildConfig) error {
 	if err := os.MkdirAll(goPath, 0o700); err != nil {
 		return errors.WithStack(err)
 	}
-	cacheDir := tools.BinariesRootPath(config.TargetPlatform)
+	cacheDir := tools.PlatformRootPath(config.TargetPlatform)
 	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
 		return errors.WithStack(err)
 	}
@@ -146,7 +146,7 @@ func buildInDocker(ctx context.Context, config BinaryBuildConfig) error {
 	nameSuffix := make([]byte, 4)
 	must.Any(rand.Read(nameSuffix))
 
-	args, envs, err := buildArgsAndEnvs(config, "/crust-cache/lib")
+	args, envs, err := buildArgsAndEnvs(config, filepath.Join("/crust-cache", tools.Version(), "lib"))
 	if err != nil {
 		return err
 	}

--- a/build/golang/lint.go
+++ b/build/golang/lint.go
@@ -155,7 +155,7 @@ func parseRegexps(strRegexps []string) ([]*regexp.Regexp, error) {
 }
 
 func lintConfigPath() string {
-	return filepath.Join(tools.VersionRootPath(tools.TargetPlatformLocal), "golangci.yaml")
+	return filepath.Join(tools.VersionedRootPath(tools.TargetPlatformLocal), "golangci.yaml")
 }
 
 func storeLintConfig(_ context.Context, _ build.DepsFunc) error {

--- a/build/golang/lint.go
+++ b/build/golang/lint.go
@@ -155,7 +155,7 @@ func parseRegexps(strRegexps []string) ([]*regexp.Regexp, error) {
 }
 
 func lintConfigPath() string {
-	return filepath.Join(tools.CacheDir(), "golangci.yaml")
+	return filepath.Join(tools.VersionRootPath(tools.TargetPlatformLocal), "golangci.yaml")
 }
 
 func storeLintConfig(_ context.Context, _ build.DepsFunc) error {

--- a/build/rust/cargo.go
+++ b/build/rust/cargo.go
@@ -39,7 +39,6 @@ func BuildSmartContract(
 		"--target-dir", targetPath,
 	)
 
-	fmt.Println(tools.Path("bin/rustc", tools.TargetPlatformLocal))
 	cmdCargo.Env = append(os.Environ(),
 		"RUSTFLAGS=-C link-arg=-s",
 		fmt.Sprintf("RUSTC=%s", tools.Path("bin/rustc", tools.TargetPlatformLocal)),

--- a/build/tools/tools.go
+++ b/build/tools/tools.go
@@ -1582,7 +1582,7 @@ func Version() string {
 
 		//This happens in two cases:
 		// - building is done in crust repository
-		// any other repository has `go.mod` modified to replace crust/build with the local source code
+		// - any other repository has `go.mod` modified to replace crust/build with the local source code
 		if m.Version == "(devel)" {
 			return "devel"
 		}

--- a/build/tools/tools.go
+++ b/build/tools/tools.go
@@ -1551,7 +1551,8 @@ func VersionedRootPath(platform TargetPlatform) string {
 
 // Path returns path to the installed binary.
 func Path(binary string, platform TargetPlatform) string {
-	return must.String(filepath.Abs(must.String(filepath.EvalSymlinks(filepath.Join(VersionedRootPath(platform), binary)))))
+	return must.String(filepath.Abs(must.String(filepath.EvalSymlinks(
+		filepath.Join(VersionedRootPath(platform), binary)))))
 }
 
 // Ensure ensures tool exists for the platform.
@@ -1580,7 +1581,7 @@ func Version() string {
 			m = m.Replace
 		}
 
-		//This happens in two cases:
+		// This happens in two cases:
 		// - building is done in crust repository
 		// - any other repository has `go.mod` modified to replace crust/build with the local source code
 		if m.Version == "(devel)" {

--- a/build/tools/tools.go
+++ b/build/tools/tools.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -593,15 +594,7 @@ func (bt BinaryTool) Ensure(ctx context.Context, platform TargetPlatform) error 
 		}
 	}
 
-	for dst := range lo.Assign(bt.Binaries, source.Binaries) {
-		if bt.Local {
-			if err := linkTool(dst); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
+	return linkTool(bt, platform, lo.Keys(lo.Assign(bt.Binaries, source.Binaries))...)
 }
 
 func (bt BinaryTool) install(ctx context.Context, platform TargetPlatform) (retErr error) {
@@ -645,16 +638,16 @@ func (bt BinaryTool) install(ctx context.Context, platform TargetPlatform) (retE
 			expectedChecksum, actualChecksum, source.URL)
 	}
 
-	dstDir := BinariesRootPath(platform)
+	dstDir := filepath.Join(toolDir, "crust")
 	for dst, src := range lo.Assign(bt.Binaries, source.Binaries) {
-		srcPath := toolDir + "/" + src
+		srcPath := filepath.Join(toolDir, src)
 
 		binChecksum, err := checksum(srcPath)
 		if err != nil {
 			return err
 		}
 
-		dstPath := dstDir + "/" + dst
+		dstPath := filepath.Join(dstDir, dst)
 		dstPathChecksum := dstPath + ":" + binChecksum
 		if err := os.Remove(dstPath); err != nil && !os.IsNotExist(err) {
 			return errors.WithStack(err)
@@ -670,9 +663,7 @@ func (bt BinaryTool) install(ctx context.Context, platform TargetPlatform) (retE
 			return errors.WithStack(err)
 		}
 		srcLinkPath := filepath.Join(
-			strings.Repeat("../", strings.Count(dst, "/")),
-			"downloads",
-			string(bt.Name)+"-"+bt.Version,
+			strings.Repeat("../", strings.Count(dst, "/")+1),
 			src,
 		)
 		if err := os.Symlink(srcLinkPath, dstPathChecksum); err != nil {
@@ -742,14 +733,14 @@ func (gpt GoPackageTool) Ensure(ctx context.Context, platform TargetPlatform) er
 			return err
 		}
 
-		srcPath := toolDir + "/" + binName
+		srcPath := filepath.Join(toolDir, binName)
 
 		binChecksum, err := checksum(srcPath)
 		if err != nil {
 			return err
 		}
 
-		dstPath := BinariesRootPath(platform) + "/" + dst
+		dstPath := filepath.Join(toolDir, "crust", dst)
 		dstPathChecksum := dstPath + ":" + binChecksum
 
 		if err := os.Remove(dstPath); err != nil && !os.IsNotExist(err) {
@@ -765,7 +756,7 @@ func (gpt GoPackageTool) Ensure(ctx context.Context, platform TargetPlatform) er
 		if err := os.Chmod(srcPath, 0o700); err != nil {
 			return errors.WithStack(err)
 		}
-		srcLinkPath := filepath.Join("..", "downloads", string(gpt.Name)+"-"+gpt.Version, binName)
+		srcLinkPath := filepath.Join("../..", binName)
 		if err := os.Symlink(srcLinkPath, dstPathChecksum); err != nil {
 			return errors.WithStack(err)
 		}
@@ -778,7 +769,7 @@ func (gpt GoPackageTool) Ensure(ctx context.Context, platform TargetPlatform) er
 		logger.Get(ctx).Info("Binary installed to path", zap.String("path", dstPath))
 	}
 
-	return linkTool(dst)
+	return linkTool(gpt, platform, dst)
 }
 
 // RustInstaller installs rust.
@@ -849,13 +840,7 @@ func (ri RustInstaller) Ensure(ctx context.Context, platform TargetPlatform) err
 		}
 	}
 
-	for _, binary := range binaries {
-		if err := linkTool(binary); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return linkTool(ri, platform, binaries...)
 }
 
 func (ri RustInstaller) install(ctx context.Context, platform TargetPlatform) (retErr error) {
@@ -919,7 +904,7 @@ func (ri RustInstaller) install(ctx context.Context, platform TargetPlatform) (r
 			return err
 		}
 
-		dstPath := filepath.Join(BinariesRootPath(platform), binary)
+		dstPath := filepath.Join(toolDir, "crust", binary)
 		dstPathChecksum := dstPath + ":" + binChecksum
 		if err := os.Remove(dstPath); err != nil && !os.IsNotExist(err) {
 			return errors.WithStack(err)
@@ -932,12 +917,7 @@ func (ri RustInstaller) install(ctx context.Context, platform TargetPlatform) (r
 			return errors.WithStack(err)
 		}
 
-		srcLinkPath := filepath.Join(
-			"..",
-			"downloads",
-			string(ri.GetName())+"-"+ri.Version,
-			filepath.Join(srcDir, binary),
-		)
+		srcLinkPath := filepath.Join("../..", filepath.Join(srcDir, binary))
 		if err := os.Symlink(srcLinkPath, dstPathChecksum); err != nil {
 			return errors.WithStack(err)
 		}
@@ -1023,6 +1003,7 @@ func (ct CargoTool) Ensure(ctx context.Context, platform TargetPlatform) error {
 		cmd := exec.Command(Path("bin/cargo", TargetPlatformLocal), "install",
 			"--version", ct.Version, "--force", "--locked",
 			"--root", toolDir, ct.Tool)
+		cmd.Env = append(os.Environ(), fmt.Sprintf("RUSTC=%s", Path("bin/rustc", TargetPlatformLocal)))
 		if err := libexec.Exec(ctx, cmd); err != nil {
 			return err
 		}
@@ -1034,7 +1015,7 @@ func (ct CargoTool) Ensure(ctx context.Context, platform TargetPlatform) error {
 			return err
 		}
 
-		dstPath := filepath.Join(BinariesRootPath(platform), binPath)
+		dstPath := filepath.Join(toolDir, "crust", binPath)
 		dstPathChecksum := dstPath + ":" + binChecksum
 
 		if err := os.Remove(dstPath); err != nil && !os.IsNotExist(err) {
@@ -1050,7 +1031,7 @@ func (ct CargoTool) Ensure(ctx context.Context, platform TargetPlatform) error {
 		if err := os.Chmod(srcPath, 0o700); err != nil {
 			return errors.WithStack(err)
 		}
-		srcLinkPath := filepath.Join("..", "downloads", string(ct.Name)+"-"+ct.Version, binPath)
+		srcLinkPath := filepath.Join("../..", binPath)
 		if err := os.Symlink(srcLinkPath, dstPathChecksum); err != nil {
 			return errors.WithStack(err)
 		}
@@ -1063,7 +1044,7 @@ func (ct CargoTool) Ensure(ctx context.Context, platform TargetPlatform) error {
 		logger.Get(ctx).Info("Binary installed to path", zap.String("path", dstPath))
 	}
 
-	return linkTool(binPath)
+	return linkTool(ct, platform, binPath)
 }
 
 // Source represents source where tool is fetched from.
@@ -1132,26 +1113,60 @@ func EnsureProtocGenBufBreaking(ctx context.Context, deps build.DepsFunc) error 
 	return Ensure(ctx, ProtocGenBufBreaking, TargetPlatformLocal)
 }
 
-func linkTool(dst string) error {
-	relink, err := shouldRelink(dst)
-	if err != nil {
-		return err
+func linkTool(tool Tool, platform TargetPlatform, binaries ...string) error {
+	for _, dst := range binaries {
+		relink, err := shouldRelink(tool, platform, dst)
+		if err != nil {
+			return err
+		}
+
+		if !relink {
+			continue
+		}
+
+		src := filepath.Join(
+			strings.Repeat("../", strings.Count(dst, "/")+1),
+			"downloads",
+			fmt.Sprintf("%s-%s", tool.GetName(), tool.GetVersion()),
+			"crust",
+			dst,
+		)
+		if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+			return errors.WithStack(err)
+		}
+
+		dstVersion := filepath.Join(VersionRootPath(platform), dst)
+
+		if err := os.Remove(dstVersion); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return errors.WithStack(err)
+		}
+
+		if err := os.MkdirAll(filepath.Dir(dstVersion), 0o700); err != nil {
+			return errors.WithStack(err)
+		}
+
+		if err := os.Symlink(src, dstVersion); err != nil {
+			return errors.WithStack(err)
+		}
+
+		if !tool.IsLocal() {
+			continue
+		}
+
+		if err := os.Remove(dst); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return errors.WithStack(err)
+		}
+
+		if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+			return errors.WithStack(err)
+		}
+
+		if err := os.Symlink(dstVersion, dst); err != nil {
+			return errors.WithStack(err)
+		}
 	}
 
-	if !relink {
-		return nil
-	}
-
-	src := filepath.Join(BinariesRootPath(TargetPlatformLocal), dst)
-	if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
-		return errors.WithStack(err)
-	}
-
-	if err := os.Remove(dst); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return errors.WithStack(err)
-	}
-
-	return errors.WithStack(os.Symlink(src, dst))
+	return nil
 }
 
 func hasher(hashStr string) (hash.Hash, string) {
@@ -1360,7 +1375,7 @@ func CacheDir() string {
 }
 
 func toolDir(tool Tool, platform TargetPlatform) string {
-	return filepath.Join(BinariesRootPath(platform), "downloads", string(tool.GetName())+"-"+tool.GetVersion())
+	return filepath.Join(PlatformRootPath(platform), "downloads", string(tool.GetName())+"-"+tool.GetVersion())
 }
 
 func ensureDir(file string) error {
@@ -1373,12 +1388,12 @@ func ensureDir(file string) error {
 func shouldReinstall(t Tool, platform TargetPlatform, src, dst string) bool {
 	toolDir := toolDir(t, platform)
 
-	srcPath, err := filepath.Abs(toolDir + "/" + src)
+	srcPath, err := filepath.Abs(filepath.Join(toolDir, src))
 	if err != nil {
 		return true
 	}
 
-	dstPath, err := filepath.Abs(filepath.Join(BinariesRootPath(platform), dst))
+	dstPath, err := filepath.Abs(filepath.Join(toolDir, "crust", dst))
 	if err != nil {
 		return true
 	}
@@ -1420,16 +1435,26 @@ func shouldReinstall(t Tool, platform TargetPlatform, src, dst string) bool {
 	return actualChecksum != expectedChecksum
 }
 
-func shouldRelink(dst string) (bool, error) {
-	dstPath := filepath.Join(BinariesRootPath(TargetPlatformLocal), dst)
+func shouldRelink(tool Tool, platform TargetPlatform, dst string) (bool, error) {
+	srcPath := filepath.Join(toolDir(tool, platform), "crust", dst)
 
-	absSrcPath, err := filepath.Abs(dstPath)
+	realSrcPath, err := filepath.EvalSymlinks(srcPath)
 	if err != nil {
 		return false, errors.WithStack(err)
 	}
-	realSrcPath, err := filepath.EvalSymlinks(absSrcPath)
+
+	versionedPath := filepath.Join(VersionRootPath(platform), dst)
+	realVersionedPath, err := filepath.EvalSymlinks(versionedPath)
 	if err != nil {
-		return false, errors.WithStack(err)
+		return true, nil //nolint:nilerr // this is ok
+	}
+
+	if realSrcPath != realVersionedPath {
+		return true, nil
+	}
+
+	if !tool.IsLocal() {
+		return false, nil
 	}
 
 	absDstPath, err := filepath.Abs(dst)
@@ -1514,14 +1539,19 @@ func CopyToolBinaries(toolName Name, platform TargetPlatform, path string, binar
 	return nil
 }
 
-// BinariesRootPath returns the root path of cached binaries.
-func BinariesRootPath(platform TargetPlatform) string {
-	return filepath.Join(CacheDir(), "bin", platform.String())
+// PlatformRootPath returns path to the directory containing all platform-secific files.
+func PlatformRootPath(platform TargetPlatform) string {
+	return filepath.Join(CacheDir(), "tools", platform.String())
+}
+
+// VersionRootPath returns the path to the root directory of crust version.
+func VersionRootPath(platform TargetPlatform) string {
+	return filepath.Join(PlatformRootPath(platform), Version())
 }
 
 // Path returns path to the installed binary.
 func Path(binary string, platform TargetPlatform) string {
-	return must.String(filepath.Abs(must.String(filepath.EvalSymlinks(filepath.Join(BinariesRootPath(platform), binary)))))
+	return must.String(filepath.Abs(must.String(filepath.EvalSymlinks(filepath.Join(VersionRootPath(platform), binary)))))
 }
 
 // Ensure ensures tool exists for the platform.
@@ -1531,4 +1561,31 @@ func Ensure(ctx context.Context, toolName Name, platform TargetPlatform) error {
 		return err
 	}
 	return tool.Ensure(ctx, platform)
+}
+
+// Version returns crust version.
+func Version() string {
+	const buildModule = "github.com/CoreumFoundation/crust/build"
+
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		panic("reading build info failed")
+	}
+
+	for _, m := range append([]*debug.Module{&bi.Main}, bi.Deps...) {
+		if m.Path != buildModule {
+			continue
+		}
+		if m.Replace != nil {
+			m = m.Replace
+		}
+
+		if m.Version == "(devel)" {
+			return "devel"
+		}
+
+		return m.Version
+	}
+
+	panic("impossible condition: crust module not found")
 }

--- a/go.work.sum
+++ b/go.work.sum
@@ -222,6 +222,7 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cosmos/cosmos-db v1.0.0-rc.1/go.mod h1:Dnmk3flSf5lkwCqvvjNpoxjpXzhxnCAFzKHlbaForso=
 github.com/cosmos/cosmos-sdk/db v1.0.0-beta.1.0.20220726092710-f848e4300a8a/go.mod h1:c8IO23vgNxueCCJlSI9awQtcxsvc+buzaeThB85qfBU=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/curioswitch/go-reassign v0.2.0/go.mod h1:x6OpXuWvgfQaMGks2BZybTngWjT84hqJfKoO8Tt/Roc=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/daixiang0/gci v0.8.1/go.mod h1:EpVfrztufwVgQRXjnX4zuNinEpLj5OmMjtu/+MB0V0c=
@@ -393,6 +394,7 @@ github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95/go.mod h1:r
 github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567/go.mod h1:DWNGW8A4Y+GyBgPuaQJuWiy0XYftx4Xm/y5Jqk9I6VQ=
 github.com/rs/cors v1.9.0 h1:l9HGsTsHJcvW14Nk7J9KFz8bzeAWXn3CG6bgt7LsrAE=
 github.com/rs/cors v1.9.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/ryancurrah/gomodguard v1.2.4/go.mod h1:+Kem4VjWwvFpUJRJSwa16s1tBJe+vbv02+naTow2f6M=
 github.com/ryanrolds/sqlclosecheck v0.3.0/go.mod h1:1gREqxyTGR3lVtpngyFo3hZAgk0KCtEdgEkHwDbigdA=
 github.com/sagikazarmark/crypt v0.10.0/go.mod h1:gwTNHQVoOS3xp9Xvz5LLR+1AauC5M6880z5NWzdhOyQ=


### PR DESCRIPTION
# Description

We are moving toward building mechanism to be local to every repository.
The side effect of this design is that every repository (at least temporarily, until everything is aligned) might import different version of `crust `, containing different versions of tools.

It might happen e.g. when we upgrade tools. First we create a new commit in `crust`, and then we must create new commits in every repository to switch to that new `crust` version. It means that our system might use different versions of tools (e.g. `go`) at the same time.

Until now we use centralized setup where all the tools are linked to the same project-global location. It cannot work this way anymore.

This PR introduces versioned environments. Version is determined by the version of `crust/build` module imported by `build` module of every repository. All the tools are linked under the version directory.

Implemented solution has some pros:
- two repositories importing different `crust/build` versions may be built together, both locally and in CI, and each repository uses the right version of the tool, preventing conflicts and incompatibilities.
- two repositories using the same version of crust, reuse the same versioned linked tools
- if two repositories import different versions of crust, but both versions of crust use the same version of a tool (e.g. go), that tool is downloaded only once, and both versioned environments link to the same tool directory
- all the stuff follows these rules, e.g. configuration of golang linter, to prevent that linting rules imported by two repositories conflict.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/339)
<!-- Reviewable:end -->
