### PR TITLE
Define lookup paths for integration test binaries

### DIFF
--- a/cmd/znet/main.go
+++ b/cmd/znet/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/CoreumFoundation/coreum-tools/pkg/run"
 	"github.com/CoreumFoundation/crust/infra"
 	"github.com/CoreumFoundation/crust/infra/apps"
+	"github.com/CoreumFoundation/crust/infra/testing"
 	"github.com/CoreumFoundation/crust/pkg/znet"
 )
 
@@ -168,7 +169,7 @@ func addTestGroupFlag(cmd *cobra.Command, configF *infra.ConfigFactory) {
 	cmd.Flags().StringSliceVar(
 		&configF.TestGroups,
 		"test-groups",
-		[]string{},
+		testing.TestGroups,
 		"Test groups in supported repositories to run integration test for,empty means all repositories all test groups ,e.g. --test-groups=faucet,coreum-modules or --test-groups=faucet --test-groups=coreum-modules", //nolint:lll // we don't care about this description
 	)
 }

--- a/pkg/znet/commands.go
+++ b/pkg/znet/commands.go
@@ -194,7 +194,7 @@ func Test(ctx context.Context, config infra.Config, spec *infra.Spec) error {
 		return err
 	}
 
-	return testing.Run(ctx, target, appSet, coredApp, config, config.TestGroups...)
+	return testing.Run(ctx, target, appSet, coredApp, config)
 }
 
 // Spec prints specification of running environment.


### PR DESCRIPTION
# Description

We are moving toward compiling artifacts locally, it means that integration test binaries no longer exist in the `crust/bin` directory. It must be defined where they exist. In transition period it is possible that they exist in crust or in specific repo.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/353)
<!-- Reviewable:end -->
