### PR TITLE
Use PackagePath as `go build` arg instead of using changing dir

### DIFF
--- a/build/golang/go.go
+++ b/build/golang/go.go
@@ -90,13 +90,13 @@ func buildLocally(ctx context.Context, config BinaryBuildConfig) error {
 		return errors.WithStack(err)
 	}
 	args, envs, err := buildArgsAndEnvs(ctx, config, libDir)
+	args = append(args, filepath.Join(config.PackagePath, "main.go"))
 	if err != nil {
 		return err
 	}
 	envs = append(envs, os.Environ()...)
 
 	cmd := exec.Command(tools.Path("bin/go", tools.TargetPlatformLocal), args...)
-	cmd.Dir = config.PackagePath
 	cmd.Env = envs
 
 	logger.Get(ctx).Info(
@@ -133,11 +133,12 @@ func buildInDocker(ctx context.Context, config BinaryBuildConfig) error {
 	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
 		return errors.WithStack(err)
 	}
-	workDir := filepath.Clean(filepath.Join(dockerRepoDir, config.PackagePath))
+	workDir := filepath.Clean(dockerRepoDir)
 	nameSuffix := make([]byte, 4)
 	must.Any(rand.Read(nameSuffix))
 
 	args, envs, err := buildArgsAndEnvs(ctx, config, filepath.Join("/crust-cache", tools.Version(), "lib"))
+	args = append(args, filepath.Clean(filepath.Join(config.PackagePath, "main.go")))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

Old command example:

```bash
go build ...  -o=bin/cored"}
```

New build command example:
```
go build ... -o=bin/cored cmd/cored/main.go"}
```

as you can see there is a slight difference in arguments. Before we used to change directory to run go build and as result output binary file `-o` was relative to build package path e.g `cmd/cored/`. As result binary was created as `repo-path/cmd/cored/bin/cored` instead of `repo-path/bin/cored`

But now we always stay in repo root  andpass path to package to be built inside go build: `go build path/to/package/main.go` so `-o` is defined relatively to repo root. 

Same applies for building packages using docker

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/369)
<!-- Reviewable:end -->
