### PR TITLE
Revert to passing `BinOutputPath` as standalone field in go build

### DIFF
--- a/build/crust/build.go
+++ b/build/crust/build.go
@@ -23,7 +23,7 @@ func BuildBuilder(ctx context.Context, deps build.DepsFunc) error {
 	return golang.Build(ctx, deps, golang.BinaryBuildConfig{
 		TargetPlatform: tools.TargetPlatformLocal,
 		PackagePath:    "build/cmd",
-		Flags:          []string{"-o=" + must.String(filepath.EvalSymlinks(must.String(os.Executable())))},
+		BinOutputPath:  must.String(filepath.EvalSymlinks(must.String(os.Executable()))),
 	})
 }
 
@@ -39,8 +39,8 @@ func BuildZNet(ctx context.Context, deps build.DepsFunc) error {
 	return golang.Build(ctx, deps, golang.BinaryBuildConfig{
 		TargetPlatform: tools.TargetPlatformLocal,
 		PackagePath:    "cmd/znet",
+		BinOutputPath:  "bin/.cache/znet",
 		CGOEnabled:     true,
-		Flags:          []string{"-o=" + "bin/.cache/znet"},
 	})
 }
 

--- a/build/golang/go.go
+++ b/build/golang/go.go
@@ -39,6 +39,9 @@ type BinaryBuildConfig struct {
 	// PackagePath is the path to package to build
 	PackagePath string
 
+	// BinOutputPath is the path for compiled binary file
+	BinOutputPath string
+
 	// CGOEnabled builds cgo binary
 	CGOEnabled bool
 
@@ -93,6 +96,7 @@ func buildLocally(ctx context.Context, config BinaryBuildConfig) error {
 	if err != nil {
 		return err
 	}
+	args = append(args, "-o", must.String(filepath.Abs(config.BinOutputPath)), ".")
 	envs = append(envs, os.Environ()...)
 
 	cmd := exec.Command(tools.Path("bin/go", tools.TargetPlatformLocal), args...)
@@ -170,6 +174,7 @@ func buildInDocker(ctx context.Context, config BinaryBuildConfig) error {
 	}
 	runArgs = append(runArgs, image)
 	runArgs = append(runArgs, args...)
+	runArgs = append(runArgs, "-o", filepath.Join(dockerRepoDir, config.BinOutputPath), ".")
 
 	cmd := exec.Command("docker", runArgs...)
 	logger.Get(ctx).Info(

--- a/build/golang/go.go
+++ b/build/golang/go.go
@@ -97,6 +97,7 @@ func buildLocally(ctx context.Context, config BinaryBuildConfig) error {
 	envs = append(envs, os.Environ()...)
 
 	cmd := exec.Command(tools.Path("bin/go", tools.TargetPlatformLocal), args...)
+	cmd.Dir = config.PackagePath
 	cmd.Env = envs
 
 	logger.Get(ctx).Info(
@@ -133,7 +134,7 @@ func buildInDocker(ctx context.Context, config BinaryBuildConfig) error {
 	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
 		return errors.WithStack(err)
 	}
-	workDir := filepath.Clean(dockerRepoDir)
+	workDir := filepath.Clean(filepath.Join(dockerRepoDir, config.PackagePath))
 	nameSuffix := make([]byte, 4)
 	must.Any(rand.Read(nameSuffix))
 

--- a/build/golang/go.go
+++ b/build/golang/go.go
@@ -93,7 +93,6 @@ func buildLocally(ctx context.Context, config BinaryBuildConfig) error {
 	if err != nil {
 		return err
 	}
-	args = append(args, toLocalGoPkgPath(config.PackagePath))
 	envs = append(envs, os.Environ()...)
 
 	cmd := exec.Command(tools.Path("bin/go", tools.TargetPlatformLocal), args...)
@@ -142,7 +141,6 @@ func buildInDocker(ctx context.Context, config BinaryBuildConfig) error {
 	if err != nil {
 		return err
 	}
-	args = append(args, toLocalGoPkgPath(config.PackagePath))
 	runArgs := []string{
 		"run", "--rm",
 		"--label", docker.LabelKey + "=" + docker.LabelValue,
@@ -189,8 +187,7 @@ func buildInDocker(ctx context.Context, config BinaryBuildConfig) error {
 func RunTests(ctx context.Context, deps build.DepsFunc, config TestConfig) error {
 	deps(EnsureGo)
 
-	args := []string{"test", toLocalGoPkgPath(config.PackagePath), "-v"}
-	args = append(args, config.Flags...)
+	args := append([]string{"test", "-v"}, config.Flags...)
 
 	cmd := exec.Command(tools.Path("bin/go", tools.TargetPlatformLocal), args...)
 
@@ -514,10 +511,4 @@ func GoPath() string {
 	}
 
 	return goPath
-}
-
-// toLocalGoPkgPath converts a path to a local go package path by prepending the "./" if needed.
-// The ./ tells the Go tool to look for the package in the local filesystem relative to the current directory.
-func toLocalGoPkgPath(path string) string {
-	return "./" + filepath.Clean(path)
 }


### PR DESCRIPTION
# Description

The original way was there for purpose. If `cmd.Dir` is not set, `go.mod` for the main module is used by the `build` command instead of the one defined in the submodule.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/385)
<!-- Reviewable:end -->
