### PR TITLE
Add more logs for Hermes API version checker script

### DIFF
--- a/infra/apps/hermes/run.tmpl
+++ b/infra/apps/hermes/run.tmpl
@@ -6,20 +6,25 @@ export HOME="{{ .HomePath }}"
 
 RELAYER_KEYS_PATH="$HOME/.hermes/keys"
 
+log_with_time() {
+  time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  echo "$time $1"
+}
+
 # The indicator to understand that relayer isn't initialized.
 if [ ! -d "$RELAYER_KEYS_PATH" ]; then
 
-  echo "Importing the relayer mnemonics."
+  log_with_time "Importing the relayer mnemonics."
   echo "{{ .CoreumRelayerMnemonic }}" > "$HOME/coreum-mnemonic"
   echo "{{ .PeerRelayerMnemonic }}" > "$HOME/peer-mnemonic"
   hermes keys add --chain {{ .CoreumChanID }} --hd-path "m/44'/{{ .CoreumRelayerCoinType }}'/0'/0/0" --mnemonic-file "$HOME/coreum-mnemonic"
   hermes keys add --chain {{ .PeerChanID }} --mnemonic-file "$HOME/peer-mnemonic"
-  echo "Connecting the chains."
+  log_with_time "Connecting the chains."
   hermes create channel --a-chain {{ .CoreumChanID }} --b-chain {{ .PeerChanID }} --a-port transfer --b-port transfer --new-client-connection --yes
 
 fi
 
-echo "Starting the relayer."
+log_with_time "Starting the relayer."
 hermes start &
 
 # Capture the process ID to kill it later if needed
@@ -29,7 +34,7 @@ INITIAL_VERSION=$(curl -s {{ .CoreumRPCURL }}/abci_info\? | jq '.result.response
 
 # If initial version is empty kill the process.
 if [ -z "$INITIAL_VERSION" ]; then
-  echo "Failed to fetch the initial API version. Exiting."
+  log_with_time "Failed to fetch the initial API version. Exiting."
   kill $PID
   exit 1
 fi
@@ -39,15 +44,17 @@ while true; do
 
   CURRENT_VERSION=$(curl -s {{ .CoreumRPCURL }}/abci_info\? | jq '.result.response.version')
 
+  log_with_time "Running API version check. Current: $CURRENT_VERSION Initial: $INITIAL_VERSION"
+
   # If fetching of version fails, skip this iteration
   if [ -z "$CURRENT_VERSION" ]; then
-    echo "API version is not available. Skipping this check."
+    log_with_time "API version is not available. Skipping this check."
     continue
   fi
 
   if [ "$INITIAL_VERSION" != "$CURRENT_VERSION" ]; then
     kill $PID
-    echo "API version changed from $INITIAL_VERSION to $CURRENT_VERSION. Process killed."
+    log_with_time "API version changed from $INITIAL_VERSION to $CURRENT_VERSION. Process killed."
     exit 1
   fi
 done


### PR DESCRIPTION
# Description

To troubleshoot the issue with randomly failing CI for IBC tests I need more info about Hermes restarting. Especially time when restart happens. It might happen that issue is caused by this script

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/387)
<!-- Reviewable:end -->
