### PR TITLE
Update rustup-init binaries to use path with same binary name

### DIFF
--- a/build/tools/tools.go
+++ b/build/tools/tools.go
@@ -397,15 +397,15 @@ var tools = []Tool{
 		Version: "1.27.0",
 		Sources: Sources{
 			TargetPlatformLinuxAMD64: {
-				URL:  "https://storage.googleapis.com/cored-build-process-binaries/rustup-init/1.27.0/x86_64-unknown-linux-gnu-rustup-init", //nolint:lll // breaking down urls is not beneficial
+				URL:  "https://storage.googleapis.com/cored-build-process-binaries/rustup-init/1.27.0/x86_64-unknown-linux-gnu/rustup-init", //nolint:lll // breaking down urls is not beneficial
 				Hash: "sha256:a3d541a5484c8fa2f1c21478a6f6c505a778d473c21d60a18a4df5185d320ef8",
 			},
 			TargetPlatformDarwinAMD64: {
-				URL:  "https://storage.googleapis.com/cored-build-process-binaries/rustup-init/1.27.0/x86_64-apple-darwin-rustup-init", //nolint:lll // breaking down urls is not beneficial
+				URL:  "https://storage.googleapis.com/cored-build-process-binaries/rustup-init/1.27.0/x86_64-apple-darwin/rustup-init", //nolint:lll // breaking down urls is not beneficial
 				Hash: "sha256:02a2d8501a567bfd43e8e0ee18ba7af0c09c84997ae7510e0f620c46293f32e0",
 			},
 			TargetPlatformDarwinARM64: {
-				URL:  "https://storage.googleapis.com/cored-build-process-binaries/rustup-init/1.27.0/aarch64-apple-darwin-rustup-init", //nolint:lll // breaking down urls is not beneficial
+				URL:  "https://storage.googleapis.com/cored-build-process-binaries/rustup-init/1.27.0/aarch64-apple-darwin/rustup-init", //nolint:lll // breaking down urls is not beneficial
 				Hash: "sha256:c30c180297a0053dcb8932ed43d365f0c9005abd847375f7ed5799a761ea81e5",
 			},
 		},


### PR DESCRIPTION
# Description

Update rustup-init binaries to use the path with the same binary name

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/395)
<!-- Reviewable:end -->
