### PR TITLE
Fix go environment variables

### DIFF
--- a/build/golang/go.go
+++ b/build/golang/go.go
@@ -83,9 +83,13 @@ func env() []string {
 		if strings.Contains(e, "PATH=") {
 			envVar = envVar + string(os.PathListSeparator) + tools.Path("bin", tools.TargetPlatformLocal)
 		}
-		if !strings.Contains(e, "GOROOT=") && !strings.Contains(e, "GOPATH=") {
+		if !strings.Contains(e, "GOROOT=") && !strings.Contains(e, "GOPATH=") && !strings.Contains(e, "GOTOOLCHAIN=") {
 			envVars = append(envVars, envVar)
 		}
+	}
+	goTool, err := tools.Get(tools.Go)
+	if err == nil {
+		envVars = append(envVars, "GOTOOLCHAIN=go"+goTool.GetVersion())
 	}
 	return envVars
 }

--- a/build/golang/go.go
+++ b/build/golang/go.go
@@ -80,6 +80,9 @@ func env() []string {
 	envVars := make([]string, 0, len(osEnv))
 	for _, envVar := range osEnv {
 		e := strings.ToUpper(envVar)
+		if strings.Contains(e, "PATH=") {
+			envVar = envVar + string(os.PathListSeparator) + tools.Path("bin", tools.TargetPlatformLocal)
+		}
 		if !strings.Contains(e, "GOROOT=") && !strings.Contains(e, "GOPATH=") {
 			envVars = append(envVars, envVar)
 		}

--- a/build/golang/go.go
+++ b/build/golang/go.go
@@ -94,7 +94,11 @@ func env() []string {
 	for _, envVar := range osEnv {
 		e := strings.ToUpper(envVar)
 		if strings.HasPrefix(e, "PATH=") {
-			envVar = prependToPathEnv(envVar, tools.Path("bin", tools.TargetPlatformLocal))
+			binPath, err := filepath.Abs("bin")
+			if err != nil {
+				panic("bin folder does not exist")
+			}
+			envVar = prependToPathEnv(envVar, binPath)
 		}
 		if !strings.HasPrefix(e, "GOROOT=") && !strings.HasPrefix(e, "GOPATH=") && !strings.HasPrefix(e, "GOTOOLCHAIN=") {
 			envVars = append(envVars, envVar)

--- a/build/golang/lint.go
+++ b/build/golang/lint.go
@@ -74,6 +74,7 @@ func lint(ctx context.Context, deps types.DepsFunc) error {
 		log.Info("Running linter", zap.String("path", path))
 		cmd := exec.Command(tools.Path("bin/golangci-lint", tools.TargetPlatformLocal), "run", "--config", config)
 		cmd.Dir = path
+		cmd.Env = env()
 		if err := libexec.Exec(ctx, cmd); err != nil {
 			return errors.Wrapf(err, "linter errors found in module '%s'", path)
 		}


### PR DESCRIPTION
# Description
Adds the binary tools path to environment variables, so mockgen can be found by go generator
Also defines explicit value for GOTOOLCHAIN to prevent using wrong toolchain

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/456)
<!-- Reviewable:end -->
