### PR TITLE
Avoid running unit tests in fuzz test

### DIFF
--- a/build/golang/go.go
+++ b/build/golang/go.go
@@ -425,6 +425,7 @@ func TestFuzz(ctx context.Context, deps types.DepsFunc, fuzzTime time.Duration) 
 					"test",
 					"-v",
 					"-fuzz", testName,
+					"-run", "^$", // An empty regex that matches nothing, to avoid running unit tests
 					"-fuzztime", fuzzTime.String(),
 					"-test.fuzzcachedir", fuzzCacheDir,
 				}


### PR DESCRIPTION
# Description
According to [Go fuzz docs](https://go.dev/doc/security/fuzz/#:~:text=By%20default%2C%20all%20other%20tests,caught%20by%20an%20existing%20test.):

> By default, all other tests in that package will run before fuzzing begins. This is to ensure that fuzzing won’t report any issues that would already be caught by an existing test.

Passing an empty regex that matches no unit test name, to avoid running them

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/461)
<!-- Reviewable:end -->
