### PR TITLE
Fix cored ext missing error

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ $COREUM_PATH/faucet/bin/faucet-builder build images
 $COREUM_PATH/callisto/bin/callisto-builder build images
 ```
 
-After the command `coreum-builder build images` completes the binaries should be copied to the crust `bin` and `.cache` directory using the following commands.
+After the command `coreum-builder build images` completes the symbolic links should be created to the crust `bin` and `.cache` directory using the following commands.
 
 ```sh
-cp -R $COREUM_PATH/coreum/bin/.cache/cored $COREUM_PATH/crust/bin/.cache/
+ln -s $COREUM_PATH/coreum/bin/.cache/cored $COREUM_PATH/crust/bin/.cache/
 ```
 
 ```sh
-cp $COREUM_PATH/coreum/bin/cored $COREUM_PATH/crust/bin/cored
+ln -s $COREUM_PATH/coreum/bin/cored $COREUM_PATH/crust/bin/cored
 ```
 
 _Note: You need to run respective builder `build images` after you modify that project.

--- a/README.md
+++ b/README.md
@@ -51,8 +51,15 @@ $COREUM_PATH/faucet/bin/faucet-builder build images
 $COREUM_PATH/callisto/bin/callisto-builder build images
 ```
 
-After the command `coreum-builder build images` completes you may find executable `$COREUM_PATH/crust/bin/cored`, being
-both blockchain node and client.
+After the command `coreum-builder build images` completes the binaries should be copied to the crust `bin` and `.cache` directory using the following commands.
+
+```sh
+cp -R $COREUM_PATH/coreum/bin/.cache/cored $COREUM_PATH/crust/bin/.cache/
+```
+
+```sh
+cp $COREUM_PATH/coreum/bin/cored $COREUM_PATH/crust/bin/cored
+```
 
 _Note: You need to run respective builder `build images` after you modify that project.
 For example if you do a modification in coreum project, you need to run `coreum-builder build images`._

--- a/znet/infra/apps/apps.go
+++ b/znet/infra/apps/apps.go
@@ -53,7 +53,7 @@ func (f *Factory) CoredNetwork(
 	ctx context.Context,
 	namePrefix string,
 	firstPorts cored.Ports,
-	validatorCount, sentryCount, seedCount, fullCount, extendedCount int,
+	validatorCount, sentryCount, seedCount, fullCount int,
 	binaryVersion string,
 	genDEX bool,
 ) (cored.Cored, []cored.Cored, error) {
@@ -111,7 +111,7 @@ func (f *Factory) CoredNetwork(
 		)
 	}
 
-	nodes := make([]cored.Cored, 0, validatorCount+seedCount+sentryCount+fullCount+extendedCount)
+	nodes := make([]cored.Cored, 0, validatorCount+seedCount+sentryCount+fullCount)
 	valNodes := make([]cored.Cored, 0, validatorCount)
 	seedNodes := make([]cored.Cored, 0, seedCount)
 	var lastNode cored.Cored
@@ -122,7 +122,6 @@ func (f *Factory) CoredNetwork(
 		isSeed := !isValidator && i < validatorCount+seedCount
 		isSentry := !isValidator && !isSeed && i < validatorCount+seedCount+sentryCount
 		isFull := !isValidator && !isSeed && !isSentry
-		isFullExtended := isFull && i >= validatorCount+seedCount+sentryCount+fullCount
 
 		name = namePrefix + fmt.Sprintf("-%02d", i)
 		dockerImage := cored.DockerImageStandard
@@ -133,9 +132,6 @@ func (f *Factory) CoredNetwork(
 			name += "-sentry"
 		case isSeed:
 			name += "-seed"
-		case isFullExtended:
-			name += "-full-ext"
-			dockerImage = cored.DockerImageExtended
 		default:
 			name += "-full"
 		}

--- a/znet/infra/apps/cored/cored.go
+++ b/znet/infra/apps/cored/cored.go
@@ -54,9 +54,6 @@ const (
 
 	// DockerImageStandard uses standard docker image of cored.
 	DockerImageStandard = "cored:znet"
-
-	// DockerImageExtended uses extended docker image of cored with cometBFT replaced.
-	DockerImageExtended = "cored-ext:znet"
 )
 
 var basicModuleList = []module.AppModuleBasic{
@@ -356,12 +353,6 @@ func (c Cored) dockerBinaryPath() string {
 		c.config.BinDir, ".cache", "cored", tools.TargetPlatformLinuxLocalArchInDocker.String(), "bin",
 	)
 	coredPath := coredStandardPath
-	if c.config.DockerImage == DockerImageExtended {
-		coredBinName = "cored-ext"
-		coredPath = filepath.Join(
-			c.config.BinDir, ".cache", "cored-ext", tools.TargetPlatformLinuxLocalArchInDocker.String(), "bin",
-		)
-	}
 
 	// by default the binary version is latest, but if `BinaryVersion` is provided we take it as initial
 	if c.Config().BinaryVersion != "" {

--- a/znet/infra/apps/profiles.go
+++ b/znet/infra/apps/profiles.go
@@ -32,7 +32,6 @@ const (
 	Profile3Cored     = "3cored"
 	Profile5Cored     = "5cored"
 	ProfileDevNet     = "devnet"
-	ProfileCoredExt   = "cored-ext"
 	ProfileIBC        = "ibc"
 	ProfileFaucet     = "faucet"
 	ProfileExplorer   = "explorer"
@@ -47,7 +46,6 @@ var profiles = []string{
 	Profile3Cored,
 	Profile5Cored,
 	ProfileDevNet,
-	ProfileCoredExt,
 	ProfileIBC,
 	ProfileFaucet,
 	ProfileExplorer,
@@ -124,11 +122,7 @@ func BuildAppSet(ctx context.Context, appF *Factory, profiles []string, coredVer
 		return profile, true
 	})
 
-	if pMap[ProfileMonitoring] {
-		pMap[ProfileCoredExt] = true
-	}
-
-	if pMap[ProfileCoredExt] || pMap[ProfileIBC] || pMap[ProfileFaucet] || pMap[ProfileXRPLBridge] ||
+	if pMap[ProfileIBC] || pMap[ProfileFaucet] || pMap[ProfileXRPLBridge] ||
 		pMap[ProfileExplorer] || pMap[ProfileMonitoring] {
 		pMap[Profile1Cored] = true
 	}
@@ -139,7 +133,7 @@ func BuildAppSet(ctx context.Context, appF *Factory, profiles []string, coredVer
 
 	MergeProfiles(pMap)
 
-	validatorCount, sentryCount, seedCount, fullCount, extendedCount := decideNumOfCoredNodes(pMap)
+	validatorCount, sentryCount, seedCount, fullCount := decideNumOfCoredNodes(pMap)
 
 	var coredApp cored.Cored
 	var appSet infra.AppSet
@@ -153,7 +147,7 @@ func BuildAppSet(ctx context.Context, appF *Factory, profiles []string, coredVer
 		ctx,
 		AppPrefixCored,
 		cored.DefaultPorts,
-		validatorCount, sentryCount, seedCount, fullCount, extendedCount,
+		validatorCount, sentryCount, seedCount, fullCount,
 		coredVersion, genDEX,
 	)
 	if err != nil {
@@ -228,22 +222,16 @@ func BuildAppSet(ctx context.Context, appF *Factory, profiles []string, coredVer
 	return appSet, coredApp, nil
 }
 
-func decideNumOfCoredNodes(pMap map[string]bool) (validatorCount, sentryCount, seedCount, fullCount,
-	extendedCount int,
-) {
-	if pMap[ProfileCoredExt] {
-		extendedCount = 1
-	}
-
+func decideNumOfCoredNodes(pMap map[string]bool) (validatorCount, sentryCount, seedCount, fullCount int) {
 	switch {
 	case pMap[Profile1Cored]:
-		return 1, 0, 0, 0, extendedCount
+		return 1, 0, 0, 0
 	case pMap[Profile3Cored]:
-		return 3, 0, 0, 0, extendedCount
+		return 3, 0, 0, 0
 	case pMap[Profile5Cored]:
-		return 5, 0, 0, 0, extendedCount
+		return 5, 0, 0, 0
 	case pMap[ProfileDevNet]:
-		return 3, 1, 1, 2, extendedCount
+		return 3, 1, 1, 2
 	default:
 		panic("no cored profile specified.")
 	}


### PR DESCRIPTION
# Description

To use crust with multiple profiles including `monitoring`, `cored-ext` which is defined in [PR#964](https://github.com/CoreumFoundation/coreum/pull/964), and it is not available in the master branch anymore. The present code change removes the deprecated `cored-ext` references.

The missing step for copying the binary from `coreum/bin` to `crust/bin` is added to the readme.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/468)
<!-- Reviewable:end -->
