### PR TITLE
Add environemnt variables to tests

### DIFF
--- a/build/golang/go.go
+++ b/build/golang/go.go
@@ -259,9 +259,7 @@ func RunTests(ctx context.Context, deps types.DepsFunc, config TestConfig) error
 
 	cmd := exec.Command(tools.Path("bin/go", tools.TargetPlatformLocal), args...)
 	cmd.Dir = config.PackagePath
-	cmd.Env = env()
-
-	cmd.Env = append(cmd.Env, config.Envs...)
+	cmd.Env = append(env(), config.Envs...)
 
 	logger.Get(ctx).Info(
 		"Running go tests",

--- a/build/golang/go.go
+++ b/build/golang/go.go
@@ -79,6 +79,9 @@ type TestConfig struct {
 
 	// Flags is a slice of additional flags to pass to `go test -c`. E.g -cover, -compiler, -ldflags=... etc.
 	Flags []string
+
+	// Envs is a slice of additional environment variables to pass to `go test -c`.
+	Envs []string
 }
 
 // env gets environment variables set in the system excluding Go env vars that
@@ -257,6 +260,8 @@ func RunTests(ctx context.Context, deps types.DepsFunc, config TestConfig) error
 	cmd := exec.Command(tools.Path("bin/go", tools.TargetPlatformLocal), args...)
 	cmd.Dir = config.PackagePath
 	cmd.Env = env()
+
+	cmd.Env = append(cmd.Env, config.Envs...)
 
 	logger.Get(ctx).Info(
 		"Running go tests",


### PR DESCRIPTION
# Description

Add environment variables to the configurations of the apps. It helps modules like integration tests to access the znet paths, binaries, etc.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/482)
<!-- Reviewable:end -->
