### PR TITLE
Remove goreleaser image after build in CI

### DIFF
--- a/build/golang/go.go
+++ b/build/golang/go.go
@@ -245,6 +245,18 @@ func buildInDocker(ctx context.Context, config BinaryBuildConfig) error {
 	if err := libexec.Exec(ctx, cmd); err != nil {
 		return errors.Wrapf(err, "building package '%s' failed", config.PackagePath)
 	}
+
+	// remove the image only in CI, to free up space
+	if os.Getenv("CI") == "true" || os.Getenv("GITHUB_ACTIONS") == "true" {
+		removeRunArgs := []string{
+			"rmi", "--force", image,
+		}
+		removeCmd := exec.Command("docker", removeRunArgs...)
+		if err := libexec.Exec(ctx, removeCmd); err != nil {
+			return errors.Wrapf(err, "removing docker image '%s' failed", image)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
# Description

This removes the image right after building. There is a drawback here, and if multiple dependencies of the same run need the same version of Go, it has to download the goreleaser every time.

To be decided: whether is accepted or define a new stap like PostBuild for the dependencies and remove the goreleaser image there.


# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/crust/483)
<!-- Reviewable:end -->
